### PR TITLE
Remove pointers to slices

### DIFF
--- a/api/cis/cisv1/dns.go
+++ b/api/cis/cisv1/dns.go
@@ -2,9 +2,10 @@ package cisv1
 
 import (
 	"fmt"
-	"github.com/IBM-Cloud/bluemix-go/client"
 	"log"
 	"time"
+
+	"github.com/IBM-Cloud/bluemix-go/client"
 )
 
 type DnsRecord struct {
@@ -46,7 +47,7 @@ type DnsBody struct {
 }
 
 type Dns interface {
-	ListDns(cisId string, zoneId string) (*[]DnsRecord, error)
+	ListDns(cisId string, zoneId string) ([]DnsRecord, error)
 	GetDns(cisId string, zoneId string, dnsId string) (*DnsRecord, error)
 	CreateDns(cisId string, zoneId string, dnsBody DnsBody) (*DnsRecord, error)
 	DeleteDns(cisId string, zoneId string, dnsId string) error
@@ -62,14 +63,14 @@ func newDnsAPI(c *client.Client) Dns {
 	}
 }
 
-func (r *dns) ListDns(cisId string, zoneId string) (*[]DnsRecord, error) {
+func (r *dns) ListDns(cisId string, zoneId string) ([]DnsRecord, error) {
 	dnsResults := DnsResults{}
 	rawURL := fmt.Sprintf("/v1/%s/zones/%s/dns_records", cisId, zoneId)
 	_, err := r.client.Get(rawURL, &dnsResults)
 	if err != nil {
 		return nil, err
 	}
-	return &dnsResults.DnsList, err
+	return dnsResults.DnsList, err
 }
 
 func (r *dns) GetDns(cisId string, zoneId string, dnsId string) (*DnsRecord, error) {

--- a/api/cis/cisv1/dns_test.go
+++ b/api/cis/cisv1/dns_test.go
@@ -73,9 +73,7 @@ var _ = Describe("Dns", func() {
 			It("should return Dns list", func() {
 				target1 := "crn:v1:staging:public:iam::::apikey:ApiKey-62fefdd1-4557-4c7d-8a1c-f6da7ee2ff3a"
 				target2 := "3fefc35e7decadb111dcf85d723a4f20"
-				myDnsPtr, err := newDns(server.URL()).ListDns(target1, target2)
-				myDns := *myDnsPtr
-				Expect(myDns).ShouldNot(BeNil())
+				myDns, err := newDns(server.URL()).ListDns(target1, target2)
 				for _, Dns := range myDns {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(Dns.Id).Should(Equal("0f4740fc36065f8a9343c7ed9445f2a4"))

--- a/api/cis/cisv1/glbs.go
+++ b/api/cis/cisv1/glbs.go
@@ -2,8 +2,9 @@ package cisv1
 
 import (
 	"fmt"
-	"github.com/IBM-Cloud/bluemix-go/client"
 	"time"
+
+	"github.com/IBM-Cloud/bluemix-go/client"
 )
 
 type Glb struct {
@@ -47,7 +48,7 @@ type GlbBody struct {
 
 type GlbDelete struct {
 	Result struct {
-		glbId string
+		GlbId string
 	} `json:"result"`
 	Success  bool     `json:"success"`
 	Errors   []Error  `json:"errors"`
@@ -55,7 +56,7 @@ type GlbDelete struct {
 }
 
 type Glbs interface {
-	ListGlbs(cisId string, zoneId string) (*[]Glb, error)
+	ListGlbs(cisId string, zoneId string) ([]Glb, error)
 	GetGlb(cisId string, zoneId string, glbId string) (*Glb, error)
 	CreateGlb(cisId string, zoneId string, glbBody GlbBody) (*Glb, error)
 	DeleteGlb(cisId string, zoneId string, glbId string) error
@@ -71,14 +72,14 @@ func newGlbAPI(c *client.Client) Glbs {
 	}
 }
 
-func (r *glbs) ListGlbs(cisId string, zoneId string) (*[]Glb, error) {
+func (r *glbs) ListGlbs(cisId string, zoneId string) ([]Glb, error) {
 	glbResults := GlbResults{}
 	rawURL := fmt.Sprintf("/v1/%s/zones/%s/load_balancers", cisId, zoneId)
 	_, err := r.client.Get(rawURL, &glbResults)
 	if err != nil {
 		return nil, err
 	}
-	return &glbResults.GlbList, err
+	return glbResults.GlbList, err
 }
 
 func (r *glbs) GetGlb(cisId string, zoneId string, glbId string) (*Glb, error) {

--- a/api/cis/cisv1/glbs_test.go
+++ b/api/cis/cisv1/glbs_test.go
@@ -75,9 +75,7 @@ var _ = Describe("Glbs", func() {
 			It("should return Glb list", func() {
 				target1 := "crn:v1:staging:public:iam::::apikey:ApiKey-62fefdd1-4557-4c7d-8a1c-f6da7ee2ff3a"
 				target2 := "3fefc35e7decadb111dcf85d723a4f20"
-				myGlbsPtr, err := newGlb(server.URL()).ListGlbs(target1, target2)
-				myGlbs := *myGlbsPtr
-				Expect(myGlbs).ShouldNot(BeNil())
+				myGlbs, err := newGlb(server.URL()).ListGlbs(target1, target2)
 				for _, Glb := range myGlbs {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(Glb.Id).Should(Equal("678106b2b5143fa9560e320961500f81"))

--- a/api/cis/cisv1/monitors.go
+++ b/api/cis/cisv1/monitors.go
@@ -2,6 +2,7 @@ package cisv1
 
 import (
 	"fmt"
+
 	"github.com/IBM-Cloud/bluemix-go/client"
 )
 
@@ -51,7 +52,7 @@ type MonitorBody struct {
 
 type MonitorDelete struct {
 	Result struct {
-		monitorId string
+		MonitorId string
 	} `json:"result"`
 	Success  bool     `json:"success"`
 	Errors   []Error  `json:"errors"`
@@ -59,7 +60,7 @@ type MonitorDelete struct {
 }
 
 type Monitors interface {
-	ListMonitors(cisId string) (*[]Monitor, error)
+	ListMonitors(cisId string) ([]Monitor, error)
 	GetMonitor(cisId string, monitorId string) (*Monitor, error)
 	CreateMonitor(cisId string, monitorBody MonitorBody) (*Monitor, error)
 	DeleteMonitor(cisId string, monitorId string) error
@@ -75,14 +76,14 @@ func newMonitorAPI(c *client.Client) Monitors {
 	}
 }
 
-func (r *monitors) ListMonitors(cisId string) (*[]Monitor, error) {
+func (r *monitors) ListMonitors(cisId string) ([]Monitor, error) {
 	monitorResults := MonitorResults{}
 	rawURL := fmt.Sprintf("/v1/%s/load_balancers/monitors/", cisId)
 	_, err := r.client.Get(rawURL, &monitorResults)
 	if err != nil {
 		return nil, err
 	}
-	return &monitorResults.MonitorList, err
+	return monitorResults.MonitorList, err
 }
 
 func (r *monitors) GetMonitor(cisId string, monitorId string) (*Monitor, error) {

--- a/api/cis/cisv1/monitors_test.go
+++ b/api/cis/cisv1/monitors_test.go
@@ -155,9 +155,7 @@ var _ = Describe("Monitors", func() {
 
 			It("should return Monitor list", func() {
 				target := "crn:v1:staging:public:iam::::apikey:ApiKey-62fefdd1-4557-4c7d-8a1c-f6da7ee2ff3a"
-				myMonitorsPtr, err := newMonitor(server.URL()).ListMonitors(target)
-				myMonitors := *myMonitorsPtr
-				Expect(myMonitors).ShouldNot(BeNil())
+				myMonitors, err := newMonitor(server.URL()).ListMonitors(target)
 				for _, Monitor := range myMonitors {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(Monitor.Id).Should(Equal("192c950172152639e21f549bc4a1cd6f"))

--- a/api/cis/cisv1/pools.go
+++ b/api/cis/cisv1/pools.go
@@ -2,6 +2,7 @@ package cisv1
 
 import (
 	"fmt"
+
 	"github.com/IBM-Cloud/bluemix-go/client"
 )
 
@@ -58,7 +59,7 @@ type PoolBody struct {
 
 type PoolDelete struct {
 	Result struct {
-		poolId string
+		PoolId string
 	} `json:"result"`
 	Success  bool     `json:"success"`
 	Errors   []Error  `json:"errors"`
@@ -66,7 +67,7 @@ type PoolDelete struct {
 }
 
 type Pools interface {
-	ListPools(cisId string) (*[]Pool, error)
+	ListPools(cisId string) ([]Pool, error)
 	GetPool(cisId string, poolId string) (*Pool, error)
 	CreatePool(cisId string, poolBody PoolBody) (*Pool, error)
 	DeletePool(cisId string, poolId string) error
@@ -82,14 +83,14 @@ func newPoolAPI(c *client.Client) Pools {
 	}
 }
 
-func (r *pools) ListPools(cisId string) (*[]Pool, error) {
+func (r *pools) ListPools(cisId string) ([]Pool, error) {
 	poolResults := PoolResults{}
 	rawURL := fmt.Sprintf("/v1/%s/load_balancers/pools/", cisId)
 	_, err := r.client.Get(rawURL, &poolResults)
 	if err != nil {
 		return nil, err
 	}
-	return &poolResults.PoolList, err
+	return poolResults.PoolList, err
 }
 
 func (r *pools) GetPool(cisId string, poolId string) (*Pool, error) {

--- a/api/cis/cisv1/pools_test.go
+++ b/api/cis/cisv1/pools_test.go
@@ -217,9 +217,7 @@ var _ = Describe("Pools", func() {
 
 			It("should return Pool list", func() {
 				target := "crn:v1:staging:public:iam::::apikey:ApiKey-62fefdd1-4557-4c7d-8a1c-f6da7ee2ff3a"
-				myPoolsPtr, err := newPool(server.URL()).ListPools(target)
-				myPools := *myPoolsPtr
-				Expect(myPools).ShouldNot(BeNil())
+				myPools, err := newPool(server.URL()).ListPools(target)
 				for _, Pool := range myPools {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(Pool.Id).Should(Equal("19901040048d70b15014330a6e252ba9"))

--- a/api/cis/cisv1/zones.go
+++ b/api/cis/cisv1/zones.go
@@ -2,6 +2,7 @@ package cisv1
 
 import (
 	"fmt"
+
 	"github.com/IBM-Cloud/bluemix-go/client"
 )
 
@@ -47,7 +48,7 @@ type ZoneBody struct {
 
 type ZoneDelete struct {
 	Result struct {
-		zoneId string
+		ZoneId string
 	} `json:"result"`
 	Success  bool     `json:"success"`
 	Errors   []Error  `json:"errors"`
@@ -55,7 +56,7 @@ type ZoneDelete struct {
 }
 
 type Zones interface {
-	ListZones(cisId string) (*[]Zone, error)
+	ListZones(cisId string) ([]Zone, error)
 	GetZone(cisId string, zoneId string) (*Zone, error)
 	CreateZone(cisId string, zoneBody ZoneBody) (*Zone, error)
 	DeleteZone(cisId string, zoneId string) error
@@ -71,14 +72,14 @@ func newZoneAPI(c *client.Client) Zones {
 	}
 }
 
-func (r *zones) ListZones(cisId string) (*[]Zone, error) {
+func (r *zones) ListZones(cisId string) ([]Zone, error) {
 	zoneResults := ZoneResults{}
 	rawURL := fmt.Sprintf("/v1/%s/zones/", cisId)
 	_, err := r.client.Get(rawURL, &zoneResults)
 	if err != nil {
 		return nil, err
 	}
-	return &zoneResults.ZoneList, err
+	return zoneResults.ZoneList, err
 }
 
 func (r *zones) GetZone(cisId string, zoneId string) (*Zone, error) {

--- a/api/cis/cisv1/zones_test.go
+++ b/api/cis/cisv1/zones_test.go
@@ -147,9 +147,7 @@ var _ = Describe("Zones", func() {
 
 			It("should return Zone list", func() {
 				target := "crn:v1:staging:public:iam::::apikey:ApiKey-62fefdd1-4557-4c7d-8a1c-f6da7ee2ff3a"
-				myZonesPtr, err := newZone(server.URL()).ListZones(target)
-				myZones := *myZonesPtr
-				Expect(myZones).ShouldNot(BeNil())
+				myZones, err := newZone(server.URL()).ListZones(target)
 				for _, Zone := range myZones {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(Zone.Id).Should(Equal("3fefc35e7decadb111dcf85d723a4f20"))

--- a/api/mccp/mccpv2/apps.go
+++ b/api/mccp/mccpv2/apps.go
@@ -68,7 +68,7 @@ type AppRequest struct {
 	DockerImage              *string                 `json:"docker_image,omitempty"`
 	StagingFailedReason      *string                 `json:"staging_failed_reason,omitempty"`
 	StagingFailedDescription *string                 `json:"staging_failed_description,omitempty"`
-	Ports                    *[]int                  `json:"ports,omitempty"`
+	Ports                    []int                   `json:"ports,omitempty"`
 	DockerCredentialsJSON    *map[string]interface{} `json:"docker_credentials_json,omitempty"`
 	EnvironmentJSON          *map[string]interface{} `json:"environment_json,omitempty"`
 }

--- a/api/mccp/mccpv2/service_instances.go
+++ b/api/mccp/mccpv2/service_instances.go
@@ -22,7 +22,7 @@ type ServiceInstanceUpdateRequest struct {
 	Name     *string                `json:"name,omitempty"`
 	PlanGUID *string                `json:"service_plan_guid,omitempty"`
 	Params   map[string]interface{} `json:"parameters,omitempty"`
-	Tags     *[]string              `json:"tags,omitempty"`
+	Tags     []string               `json:"tags,omitempty"`
 }
 
 //ServiceInstance ...

--- a/helpers/conversion.go
+++ b/helpers/conversion.go
@@ -17,6 +17,16 @@ func String(v string) *string {
 	return &v
 }
 
+// Map returns a pointer to the map value
+func Map(v map[string]interface{}) *map[string]interface{} {
+	return &v
+}
+
+// IntSlice returns a pointer to the IntSlice value
+func IntSlice(v []int) *[]int {
+	return &v
+}
+
 // Duration returns a pointer to the time.Duration
 func Duration(v time.Duration) *time.Duration {
 	return &v

--- a/helpers/conversion.go
+++ b/helpers/conversion.go
@@ -17,16 +17,6 @@ func String(v string) *string {
 	return &v
 }
 
-// Map returns a pointer to the map value
-func Map(v map[string]interface{}) *map[string]interface{} {
-	return &v
-}
-
-// IntSlice returns a pointer to the IntSlice value
-func IntSlice(v []int) *[]int {
-	return &v
-}
-
 // Duration returns a pointer to the time.Duration
 func Duration(v time.Duration) *time.Duration {
 	return &v


### PR DESCRIPTION
Changed returns types of *[]<T> to just []<T>, *[] aren't rangeable and
don't provide any benefit as [] is a pointer.
Also some struct fields for json responses weren't exported so could not
have been populated.

Also removed helper functions for providing pointers to slices and maps