### PR TITLE
Support /v1/versions to get openshift versions.

### DIFF
--- a/api/container/containerv1/versions.go
+++ b/api/container/containerv1/versions.go
@@ -12,9 +12,12 @@ type KubeVersion struct {
 	Default bool
 }
 
+type v1version map[string][]KubeVersion
+
 //KubeVersions interface
 type KubeVersions interface {
 	List(target ClusterTargetHeader) ([]KubeVersion, error)
+	ListV1(target ClusterTargetHeader) (v1version, error)
 }
 
 type version struct {
@@ -35,4 +38,14 @@ func (v *version) List(target ClusterTargetHeader) ([]KubeVersion, error) {
 		return nil, err
 	}
 	return versions, err
+}
+
+func (v *version) ListV1(target ClusterTargetHeader) (v1version, error) {
+	v1ver := v1version{}
+	_, err := v.client.Get("/v1/versions", &v1ver, target.ToMap())
+	if err != nil {
+		return nil, err
+	}
+
+	return v1ver, err
 }

--- a/examples/container/versions/main.go
+++ b/examples/container/versions/main.go
@@ -88,4 +88,10 @@ func main() {
 		log.Fatal(err)
 	}
 	fmt.Println(out)
+
+	outv1, err := clustersAPI.ListV1(target)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(outv1)
 }


### PR DESCRIPTION
Implemented #155 
Signed-off-by: Yu Wei <yuweiw@cn.ibm.com>

Output after running examples code examples/container/versions is as below,
```
weis-mbp:versions weiyu$ go run main.go 
[{1 12 10 false} {1 13 11 false} {1 14 7 true} {1 15 4 false}]
map[kubernetes:[{1 12 10 false} {1 13 11 false} {1 14 7 true} {1 15 4 false}] openshift:[{3 11 146 false}]]
```