### PR TITLE
fix: Support for retry on 520 status code

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -323,7 +323,7 @@ func getDefaultAuthHeaders(serviceName bluemix.ServiceName, c *bluemix.Config) g
 func isTimeout(err error) bool {
 	if bmErr, ok := err.(bmxerror.RequestFailure); ok {
 		switch bmErr.StatusCode() {
-		case 408, 504, 599, 429, 500, 502:
+		case 408, 504, 599, 429, 500, 502, 520:
 			return true
 		}
 	}


### PR DESCRIPTION
Observed error..
```
Request failed with status code: 520, ServerErrorResponse: <!DOCTYPE html>
<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]-->
<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en-US"> <![endif]-->
<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en-US"> <![endif]-->
<!--[if gt IE 8]><!--> <html class="no-js" lang="en-US"> <!--<![endif]-->
<head>
<meta http-equiv="refresh" content="0">
<title>us-south.containers.cloud.ibm.com | 520: Web server is returning an unknown error</title>
<meta charset="UTF-8" />
<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />
<meta name="robots" content="noindex, nofollow" />
<meta name="viewport" content="width=device-width,initial-scale=1" />
<link rel="stylesheet" id="cf_styles-css" href="/cdn-cgi/styles/cf.errors.css" type="text/css" media="screen,projection" />
```

Ideally, 520 errors should be included in the retry list as well.