### PR TITLE
Handled ServerURL/MasterURL for the vpc clusters

### DIFF
--- a/api/container/containerv1/clusters.go
+++ b/api/container/containerv1/clusters.go
@@ -31,6 +31,7 @@ type ClusterInfo struct {
 	Region                        string   `json:"region"`
 	ResourceGroupID               string   `json:"resourceGroup"`
 	ServerURL                     string   `json:"serverURL"`
+	MasterURL                     string   `json:"masterURL"` // vpc cluster serverURL is empty
 	State                         string   `json:"state"`
 	OrgID                         string   `json:"logOrg"`
 	OrgName                       string   `json:"logOrgName"`
@@ -368,6 +369,10 @@ func (r *clusters) FindWithOutShowResourcesCompatible(name string, target Cluste
 	_, err := r.client.Get(rawURL, &cluster, target.ToMap())
 	if err != nil {
 		return cluster, err
+	}
+	// Handle VPC cluster.  ServerURL is blank for v2/vpc clusters
+	if cluster.ServerURL == "" {
+		cluster.ServerURL = cluster.MasterURL
 	}
 	return cluster, err
 }


### PR DESCRIPTION
No ServerURL property returned for the VPC cluster . See the below rest api output>
Used masterURL as a Server URL for VPC clusters 
```
root@prgavali1:~/go_workspace/src/test-go# curl -X GET -H "Authorization: $IAM_TOKEN" -H "Content-Type: application/json" "https://containers.cloud.ibm.com/v2/getCluster?v1-compatible&cluster=mycluster2-gen2" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1585  100  1585    0     0    762      0  0:00:02  0:00:02 --:--:--   762
{
  "id": "bqp9aj9d0b914bomgo8g",
  "name": "mycluster2-gen2",
  "region": "us-south",
  "resourceGroup": "590a67db1ed242afbfaac997650133e5",
  "resourceGroupName": "default",
  "createdDate": "2020-05-06T10:45:33+0000",
  "masterKubeVersion": "1.17.6_1526",
  "targetVersion": "1.17.6_1526",
  "workerCount": 3,
  "location": "Dallas",
  "datacenter": "dal10",
  "multiAzCapable": true,
  "provider": "vpc-gen2",
  "state": "normal",
  "versionEOS": "",
  "isPaid": true,
  "entitlement": "",
  "type": "kubernetes",
  "addons": null,
  "etcdPort": "",
  "masterURL": "https://c108.us-south.containers.cloud.ibm.com:32728",
  "ingress": {
    "hostname": "mycluster2-gen2-915d68e34553ddc64ff2a5f78049b3c1-0000.us-south.containers.appdomain.cloud",
    "secretName": "mycluster2-gen2-915d68e34553ddc64ff2a5f78049b3c1-0000",
    "status": "",
    "message": ""
  },
  "ownerEmail": "prgavali@in.ibm.com",
  "disableAutoUpdate": false,
  "crn": "crn:v1:bluemix:public:containers-kubernetes:us-south:a/47903c027b26810fbee277506680e001:bqp9aj9d0b914bomgo8g::",
  "podSubnet": "172.17.64.0/18",
  "serviceSubnet": "172.21.0.0/16",
  "workerZones": [
    "us-south-1"
  ],
  "lifecycle": {
    "masterStatus": "Ready",
    "masterStatusModifiedDate": "2020-05-28T17:28:34+0000",
    "masterHealth": "normal",
    "masterState": "deployed",
    "modifiedDate": "2020-05-06T10:46:22+0000"
  },
  "serviceEndpoints": {
    "privateServiceEndpointEnabled": true,
    "privateServiceEndpointURL": "https://c108.private.us-south.containers.cloud.ibm.com:32728",
    "publicServiceEndpointEnabled": true,
    "publicServiceEndpointURL": "https://c108.us-south.containers.cloud.ibm.com:32728"
  },
  "features": {
    "keyProtectEnabled": false,
    "pullSecretApplied": true
  },
  "vpcs": [
    "r006-831eff2f-d14c-48b0-adee-cb3c50e009d9"
  ]
}
```