### PR TITLE
Add `eu-fr2` as valid ICD endpoint

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -86,6 +86,7 @@ var regionToEndpoint = map[string]map[string]string{
 		"us-south": "https://api.us-south.databases.cloud.ibm.com",
 		"us-east":  "https://api.us-east.databases.cloud.ibm.com",
 		"eu-de":    "https://api.eu-de.databases.cloud.ibm.com",
+		"eu-fr2":   "https://api.eu-fr2.databases.cloud.ibm.com",
 		"eu-gb":    "https://api.eu-gb.databases.cloud.ibm.com",
 		"au-syd":   "https://api.au-syd.databases.cloud.ibm.com",
 		"jp-tok":   "https://api.jp-tok.databases.cloud.ibm.com",


### PR DESCRIPTION
To be able to manage databases inside the `eu-fr2` region we need
to define the API endpoint.