### PR TITLE
fix: Remove extra println statement

### DIFF
--- a/api/container/containerv1/clusters.go
+++ b/api/container/containerv1/clusters.go
@@ -588,7 +588,6 @@ func (r *clusters) GetClusterConfigDetail(name, dir string, admin bool, target C
 		openshiftusers := openshiftyaml.Users
 		for _, usr := range openshiftusers {
 			if strings.HasPrefix(usr.Name, "IAM") {
-				fmt.Println("Tokennnnnn", usr.User.Token)
 				clusterkey.Token = usr.User.Token
 			}
 		}


### PR DESCRIPTION
Looks like there is an extra message, perhaps left over from debugging, which will leak tokens over `stdout`.