### PR TITLE
Added support for vpc volume attachment

### DIFF
--- a/api/container/containerv2/workers.go
+++ b/api/container/containerv2/workers.go
@@ -55,12 +55,45 @@ type ReplaceWorker struct {
 	WorkerID        string `json:"workerID"`
 }
 
+type VoulemeAttachments struct {
+	VolumeAttachments []VoulemeAttachment `json:"volume_attachments"`
+}
+
+type VoulemeAttachment struct {
+	Id     string     `json:"id"`
+	Volume Volume     `json:"volume"`
+	Device DeviceInfo `json:"device"`
+	Name   string     `json:"name"`
+	Status string     `json:"status"`
+	Type   string     `json:"type"`
+}
+
+type Volume struct {
+	Name string `json:"name"`
+	Id   string `json:"id"`
+}
+
+type DeviceInfo struct {
+	Id string `json:"id"`
+}
+
+type VolumeRequest struct {
+	Cluster            string `json:"cluster"`
+	VolumeAttachmentID string `json:"volumeAttachmentID,omitempty"`
+	VolumeID           string `json:"volumeID,omitempty"`
+	Worker             string `json:"worker"`
+}
+
 //Workers ...
 type Workers interface {
 	ListByWorkerPool(clusterIDOrName, workerPoolIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error)
 	ListWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error)
 	Get(clusterIDOrName, workerID string, target ClusterTargetHeader) (Worker, error)
 	ReplaceWokerNode(clusterIDOrName, workerID string, target ClusterTargetHeader) (string, error)
+	ListStorageAttachemnts(clusterIDOrName, workerID string, target ClusterTargetHeader) (VoulemeAttachments, error)
+	GetStorageAttachment(clusterIDOrName, workerID, volumeAttachmentID string, target ClusterTargetHeader) (VoulemeAttachment, error)
+	CreateStorageAttachment(payload VolumeRequest, target ClusterTargetHeader) (VoulemeAttachment, error)
+	DeleteStorageAttachment(payload VolumeRequest, target ClusterTargetHeader) (string, error)
 }
 
 type worker struct {
@@ -117,6 +150,47 @@ func (r *worker) ReplaceWokerNode(clusterIDOrName, workerID string, target Clust
 	}
 	var response string
 	_, err := r.client.Post("/v2/vpc/replaceWorker", payload, &response, target.ToMap())
+	if err != nil {
+		return response, err
+	}
+	return response, err
+}
+
+// ListStorageAttachemnts returns list of attached storage blaocks to a worker node
+func (r *worker) ListStorageAttachemnts(clusterIDOrName, workerID string, target ClusterTargetHeader) (VoulemeAttachments, error) {
+	rawURL := fmt.Sprintf("/v2/storage/getAttachments?cluster=%s&worker=%s", clusterIDOrName, workerID)
+	workerAttachements := VoulemeAttachments{}
+	_, err := r.client.Get(rawURL, &workerAttachements, target.ToMap())
+	if err != nil {
+		return workerAttachements, err
+	}
+	return workerAttachements, err
+
+}
+
+func (r *worker) GetStorageAttachment(clusterIDOrName, workerID, volumeAttachmentID string, target ClusterTargetHeader) (VoulemeAttachment, error) {
+	rawURL := fmt.Sprintf("/v2/storage/getAttachment?cluster=%s&worker=%s&volumeAttachmentID=%s", clusterIDOrName, workerID, volumeAttachmentID)
+	workerAttachement := VoulemeAttachment{}
+	_, err := r.client.Get(rawURL, &workerAttachement, target.ToMap())
+	if err != nil {
+		return workerAttachement, err
+	}
+	return workerAttachement, err
+
+}
+
+func (r *worker) CreateStorageAttachment(payload VolumeRequest, target ClusterTargetHeader) (VoulemeAttachment, error) {
+	response := VoulemeAttachment{}
+	_, err := r.client.Post("/v2/storage/createAttachment", payload, &response, target.ToMap())
+	if err != nil {
+		return response, err
+	}
+	return response, err
+}
+
+func (r *worker) DeleteStorageAttachment(payload VolumeRequest, target ClusterTargetHeader) (string, error) {
+	var response string
+	_, err := r.client.Post("/v2/storage/deleteAttachment", payload, &response, target.ToMap())
 	if err != nil {
 		return response, err
 	}

--- a/examples/container/V2containers/AttachStorageV2/main.go
+++ b/examples/container/V2containers/AttachStorageV2/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	bluemix "github.com/IBM-Cloud/bluemix-go"
+	"github.com/IBM-Cloud/bluemix-go/session"
+	"github.com/IBM-Cloud/bluemix-go/trace"
+
+	v2 "github.com/IBM-Cloud/bluemix-go/api/container/containerv2"
+)
+
+func main() {
+
+	var clusterID string
+	flag.StringVar(&clusterID, "clusterID", "", "Cluster ID or Name")
+
+	var workerID string
+	flag.StringVar(&workerID, "workerID", "", "worker ID of the worker node in the cluster")
+
+	var volumeID string
+	flag.StringVar(&volumeID, "volumeID", "", "volumeID of the volume to be attched to the worker")
+
+	flag.Parse()
+
+	if clusterID == "" || workerID == "" || volumeID == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+	c := new(bluemix.Config)
+
+	trace.Logger = trace.NewLogger("true")
+
+	sess, err := session.New(c)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	target := v2.ClusterTargetHeader{}
+
+	clusterClient, err := v2.New(sess)
+	if err != nil {
+		log.Fatal(err)
+	}
+	workersAPI := clusterClient.Workers()
+
+	attachVolumeRequest := v2.VolumeRequest{
+		Cluster:  clusterID,
+		VolumeID: volumeID,
+		Worker:   workerID,
+	}
+	volumeattached, errC := workersAPI.CreateStorageAttachment(attachVolumeRequest, target)
+	if errC != nil {
+		fmt.Println(errC)
+		return
+	}
+	fmt.Println("Volume attached: ", volumeattached)
+	volumeAttachmentID := volumeattached.Id
+	time.Sleep(10 * time.Second)
+
+	volumeAttachment, errG := workersAPI.GetStorageAttachment(clusterID, workerID, volumeAttachmentID, target)
+	if errG != nil {
+		fmt.Println(errG)
+		return
+	}
+	fmt.Println("Volume attachment with worker nodes: ", volumeAttachment)
+	time.Sleep(5 * time.Second)
+
+	detachVolumeRequest := v2.VolumeRequest{
+		Cluster:            clusterID,
+		VolumeAttachmentID: volumeAttachmentID,
+		Worker:             workerID,
+	}
+	out, errD := workersAPI.DeleteStorageAttachment(detachVolumeRequest, target)
+	if errD != nil {
+		fmt.Println(errD)
+		return
+	}
+	fmt.Println("Volume attachment removed", out)
+}


### PR DESCRIPTION
This PR supports:

VPC volume attachment operations on IKS cluster worker node.
