### PR TITLE
Use icr.io domain endpoints for Container Registry

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -58,12 +58,12 @@ var regionToEndpoint = map[string]map[string]string{
 		"jp-tok":   "https://api.jp-tok.bluemix.net",
 	},
 	"cr": {
-		"us-south": "https://registry.ng.bluemix.net",
-		"us-east":  "https://registry.ng.bluemix.net",
-		"eu-de":    "https://registry.eu-de.bluemix.net",
-		"au-syd":   "https://registry.au-syd.bluemix.net",
-		"eu-gb":    "https://registry.eu-gb.bluemix.net",
-		"jp-tok":   "https://registry.jp-tok.bluemix.net",
+		"us-south": "https://us.icr.io",
+		"eu-de":    "https://de.icr.io",
+		"au-syd":   "https://au.icr.io",
+		"eu-gb":    "https://uk.icr.io",
+		"jp-tok":   "https://jp.icr.io",
+		"jp-osa":   "https://jp2.icr.io",
 	},
 	"cs": {
 		"global": "https://containers.cloud.ibm.com/global",

--- a/endpoints/endpoints_test.go
+++ b/endpoints/endpoints_test.go
@@ -15,7 +15,7 @@ var _ = Describe("EndPoints", func() {
 			Expect(locator.UAAEndpoint()).To(Equal("https://iam.cloud.ibm.com/cloudfoundry/login/us-south"))
 			Expect(locator.ICDEndpoint()).To(Equal("https://api.us-south.databases.cloud.ibm.com"))
 			Expect(locator.MCCPAPIEndpoint()).To(Equal("https://mccp.us-south.cf.cloud.ibm.com"))
-			Expect(locator.ContainerRegistryEndpoint()).To(Equal("https://registry.ng.bluemix.net"))
+			Expect(locator.ContainerRegistryEndpoint()).To(Equal("https://us.icr.io"))
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: James Hart <jhart@uk.ibm.com>
The previous settings use deprecated bluemix.net domains. There are a couple of specific problems:
- Newer registry instances (jp-tok and jp-osa) do not have bluemix.net. The previous setting for `jp-tok` would not have worked.
- us-east should not really have been on the list. Unless there is a strong requirement to invisibly map us-east to the us-south registry, I think it is clearer to remove it.