### PR TITLE
Correcting the API endpoint to be called to get ClusterInfo

### DIFF
--- a/api/container/containerv2/clusters.go
+++ b/api/container/containerv2/clusters.go
@@ -216,11 +216,12 @@ func (r *clusters) Delete(name string, target ClusterTargetHeader, deleteDepende
 //GetClusterByIDorName
 func (r *clusters) GetCluster(name string, target ClusterTargetHeader) (*ClusterInfo, error) {
 	ClusterInfo := &ClusterInfo{}
-	rawURL := fmt.Sprintf("/v2/vpc/getCluster?cluster=%s", name)
+	rawURL := fmt.Sprintf("/v2/getCluster?cluster=%s&v1-compatible", name)
 	_, err := r.client.Get(rawURL, &ClusterInfo, target.ToMap())
 	if err != nil {
 		return nil, err
 	}
+
 	return ClusterInfo, err
 }
 func (r *ClusterInfo) IsStagingSatelliteCluster() bool {


### PR DESCRIPTION
In case of v2 we should call global/v2/getCluster not /v2/vpc/getCluster
Corrected the endpoint, tested with ibmcloud cli and small test program.

Signed-off-by: Tapas Sharma <tapas@portworx.com>