### PR TITLE
fix: Increase robustness of openshift login flow

### DIFF
--- a/api/container/containerv2/openshift.go
+++ b/api/container/containerv2/openshift.go
@@ -230,7 +230,13 @@ func (r *clusters) openShiftAuthorizePasscode(authEP *authEndpoints, passcode st
 		resp, err = r.client.SendRequest(request, respInterface)
 		if err != nil {
 			if resp.StatusCode != 302 {
-				return "", "", err
+				// Retry at least 3 times before returning error to caller
+				if try >= 3 {
+					return "", "", err
+				} else {
+					time.Sleep(200 * time.Millisecond)
+					continue
+				}
 			}
 		}
 		defer resp.Body.Close()

--- a/api/container/containerv2/openshift.go
+++ b/api/container/containerv2/openshift.go
@@ -122,7 +122,7 @@ func (r *clusters) FetchOCTokenForKubeConfig(kubecfg []byte, cMeta *ClusterInfo,
 	trace.Logger.Println("Creating user passcode to login for getting oc token")
 
 	// Retry to cover rate limiting on passcode endpoint in particular
-	for try := 1; err != nil && try <= 3; try++ {
+	for try := 1; try <= 3; try++ {
 		passcode, err = r.client.TokenRefresher.GetPasscode()
 
 		if err == nil {

--- a/api/container/containerv2/openshift.go
+++ b/api/container/containerv2/openshift.go
@@ -156,8 +156,17 @@ func (r *clusters) FetchOCTokenForKubeConfig(kubecfg []byte, cMeta *ClusterInfo,
 		return &auth, nil
 	}(cMeta)
 
+	if err != nil {
+		return kubecfg, err
+	}
+
 	trace.Logger.Println("Got authentication end points for getting oc token")
 	token, uname, err := r.openShiftAuthorizePasscode(authEP, passcode, cMeta.IsStagingSatelliteCluster())
+
+	if err != nil {
+		return kubecfg, err
+	}
+
 	trace.Logger.Println("Got the token and user ", uname)
 	clusterName, _ := NormalizeName(authEP.ServerURL[len("https://"):len(authEP.ServerURL)]) //TODO deal with http
 	ccontext := "default/" + clusterName + "/" + uname


### PR DESCRIPTION
This PR increases the robustness of the openshift login flow:
- Retries on retrieving the passcode ( including covering of the rate limit that kicks in)
- Race condition (around request headers) that existed in previous version as the same rest client instance was reused without proper locking. Some threads in previous code was effectively essentially removing the auth headers causing any parallel and subsequent request to fail with 401.
- Exiting with error when passcode cannot be retrieved - ensuring the user is not unexpectedly authenticated as 'anonymous'
- Handling of intermittent issue where openshift returns a 200 instead of a 302 with accesscode on authentication flow

Context: We've been plagued with a number of authentication / login issue in our terraform code. The IBM Cloud terraform provider makes intensive use. See in particular https://github.com/IBM-Cloud/terraform-provider-ibm/issues/2811