### PR TITLE
:zap: Added support for ResizeWorkerPool() API in containerv2

### DIFF
--- a/api/container/containerv2/worker_pool.go
+++ b/api/container/containerv2/worker_pool.go
@@ -61,6 +61,12 @@ type Subnet struct {
 	Primary bool   `json:"primary"`
 }
 
+type ResizeWorkerPoolReq struct {
+	Cluster    string `json:"cluster"`
+	Size       int64  `json:"size"`
+	Workerpool string `json:"workerpool"`
+}
+
 //Workers ...
 type WorkerPool interface {
 	CreateWorkerPool(workerPoolReq WorkerPoolRequest, target ClusterTargetHeader) (WorkerPoolResponse, error)
@@ -69,6 +75,7 @@ type WorkerPool interface {
 	CreateWorkerPoolZone(workerPoolZone WorkerPoolZone, target ClusterTargetHeader) error
 	DeleteWorkerPool(clusterNameOrID string, workerPoolNameOrID string, target ClusterTargetHeader) error
 	UpdateWorkerPoolTaints(taintRequest WorkerPoolTaintRequest, target ClusterTargetHeader) error
+	ResizeWorkerPool(resizeWorkerPoolReq ResizeWorkerPoolReq, target ClusterTargetHeader) error
 }
 
 type workerpool struct {
@@ -120,5 +127,12 @@ func (w *workerpool) CreateWorkerPoolZone(workerPoolZone WorkerPoolZone, target 
 func (w *workerpool) UpdateWorkerPoolTaints(taintRequest WorkerPoolTaintRequest, target ClusterTargetHeader) error {
 	// Make the request, don't care about return value
 	_, err := w.client.Post("/v2/setWorkerPoolTaints", taintRequest, nil, target.ToMap())
+	return err
+}
+
+// ResizeWorkerPool calls the API to resize an existing worker pool.
+func (w *workerpool) ResizeWorkerPool(resizeWorkerPoolReq ResizeWorkerPoolReq, target ClusterTargetHeader) error {
+	// Make the request, don't care about return value
+	_, err := w.client.Post("/v2/resizeWorkerPool", resizeWorkerPoolReq, nil, target.ToMap())
 	return err
 }

--- a/api/container/containerv2/worker_pool_test.go
+++ b/api/container/containerv2/worker_pool_test.go
@@ -253,6 +253,55 @@ var _ = Describe("workerpools", func() {
 				Expect(err).To(HaveOccurred())
 			})
 		})
+
+		//Resize
+		Describe("Resize", func() {
+			Context("When resizing workerpool is successful", func() {
+				BeforeEach(func() {
+					server = ghttp.NewServer()
+					server.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest(http.MethodPost, "/v2/resizeWorkerPool"),
+							ghttp.VerifyJSON(`{"cluster":"bm64u3ed02o93vv36hb0","workerpool":"mywork211","size":5}`),
+						),
+					)
+				})
+				It("should resize Workerpool in a cluster", func() {
+					target := ClusterTargetHeader{}
+					params := ResizeWorkerPoolReq{
+						Cluster:    "bm64u3ed02o93vv36hb0",
+						Workerpool: "mywork211",
+						Size:       5,
+					}
+					err := newWorkerPool(server.URL()).ResizeWorkerPool(params, target)
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+			Context("When resizing workerpool is unsuccessful", func() {
+				BeforeEach(func() {
+					server = ghttp.NewServer()
+					server.SetAllowUnhandledRequests(true)
+					server.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest(http.MethodPost, "/v2/resizeWorkerPool"),
+							ghttp.VerifyJSON(`{"cluster":"bm64u3ed02o93vv36hb0","workerpool":"mywork211","size":5}`),
+							ghttp.RespondWith(http.StatusInternalServerError, `Failed to resize workerpool`),
+						),
+					)
+				})
+
+				It("should return error during resizing workerpool", func() {
+					params := ResizeWorkerPoolReq{
+						Cluster:    "bm64u3ed02o93vv36hb0",
+						Workerpool: "mywork211",
+						Size:       5,
+					}
+					target := ClusterTargetHeader{}
+					err := newWorkerPool(server.URL()).ResizeWorkerPool(params, target)
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
Added `ResizeWorkerPool()` API to container V2.

Corrosponding REST API definition: https://cloud.ibm.com/apidocs/kubernetes#v2resizeworkerpool