### PR TITLE
add SecondaryStorageOption to cluster and workerpool operations

### DIFF
--- a/api/container/containerv2/clusters_test.go
+++ b/api/container/containerv2/clusters_test.go
@@ -263,6 +263,42 @@ var _ = Describe("Clusters", func() {
 				Expect(myCluster.ID).Should(Equal("f91adfe2-76c9-4649-939e-b01c37a3704c"))
 			})
 		})
+		Context("When creation with SecondaryStorageOption is successful", func() {
+			BeforeEach(func() {
+				server = ghttp.NewServer()
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPost, "/v2/vpc/createCluster"),
+						ghttp.VerifyJSON(`{"disablePublicServiceEndpoint": false, "defaultWorkerPoolEntitlement": "", "kubeVersion": "", "podSubnet": "podnet", "provider": "abc", "serviceSubnet": "svcnet", "name": "abcd", "cosInstanceCRN": "", "workerPool": {"flavor": "", "hostPoolID": "hostpoolid", "name": "", "vpcID": "", "workerCount": 0, "zones": null, "entitlement": "", "secondaryStorageOption": "secondarystoragename1"}}`),
+						ghttp.RespondWith(http.StatusCreated, `{
+							 "clusterID": "f91adfe2-76c9-4649-939e-b01c37a3704c"
+						}`),
+					),
+				)
+			})
+
+			It("should return cluster created", func() {
+				WPools := WorkerPoolConfig{
+					CommonWorkerPoolConfig: CommonWorkerPoolConfig{
+						Flavor:                 "",
+						WorkerCount:            0,
+						VpcID:                  "",
+						Name:                   "",
+						SecondaryStorageOption: "secondarystoragename1",
+					},
+					HostPoolID: "hostpoolid",
+				}
+				params := ClusterCreateRequest{
+					DisablePublicServiceEndpoint: false, KubeVersion: "", PodSubnet: "podnet", Provider: "abc", ServiceSubnet: "svcnet", Name: "abcd", WorkerPools: WPools, CosInstanceCRN: "",
+				}
+				target := ClusterTargetHeader{}
+				myCluster, err := newCluster(server.URL()).Create(params, target)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(myCluster).ShouldNot(BeNil())
+				Expect(myCluster.ID).Should(Equal("f91adfe2-76c9-4649-939e-b01c37a3704c"))
+			})
+		})
+
 		Context("When creation is unsuccessful", func() {
 			BeforeEach(func() {
 				server = ghttp.NewServer()

--- a/api/container/containerv2/worker_pool.go
+++ b/api/container/containerv2/worker_pool.go
@@ -19,6 +19,7 @@ type CommonWorkerPoolConfig struct {
 	WorkerCount            int                     `json:"workerCount"`
 	Zones                  []Zone                  `json:"zones"`
 	WorkerVolumeEncryption *WorkerVolumeEncryption `json:"workerVolumeEncryption,omitempty"`
+	SecondaryStorageOption string                  `json:"secondaryStorageOption,omitempty"`
 }
 
 // WorkerPoolRequest provides worker pool data
@@ -48,20 +49,33 @@ type WorkerPoolZone struct {
 }
 
 type GetWorkerPoolResponse struct {
-	HostPoolID             string            `json:"dedicatedHostPoolId,omitempty"`
-	Flavor                 string            `json:"flavor"`
-	ID                     string            `json:"id"`
-	Isolation              string            `json:"isolation"`
-	Labels                 map[string]string `json:"labels,omitempty"`
-	OperatingSystem        string            `json:"operatingSystem,omitempty"`
-	Taints                 map[string]string `json:"taints,omitempty"`
-	Lifecycle              `json:"lifecycle"`
-	VpcID                  string                  `json:"vpcID"`
-	WorkerCount            int                     `json:"workerCount"`
-	PoolName               string                  `json:"poolName"`
-	Provider               string                  `json:"provider"`
-	Zones                  []ZoneResp              `json:"zones"`
-	WorkerVolumeEncryption *WorkerVolumeEncryption `json:"workerVolumeEncryption,omitempty"`
+	HostPoolID               string            `json:"dedicatedHostPoolId,omitempty"`
+	Flavor                   string            `json:"flavor"`
+	ID                       string            `json:"id"`
+	Isolation                string            `json:"isolation"`
+	Labels                   map[string]string `json:"labels,omitempty"`
+	OperatingSystem          string            `json:"operatingSystem,omitempty"`
+	Taints                   map[string]string `json:"taints,omitempty"`
+	Lifecycle                `json:"lifecycle"`
+	VpcID                    string                  `json:"vpcID"`
+	WorkerCount              int                     `json:"workerCount"`
+	PoolName                 string                  `json:"poolName"`
+	Provider                 string                  `json:"provider"`
+	Zones                    []ZoneResp              `json:"zones"`
+	WorkerVolumeEncryption   *WorkerVolumeEncryption `json:"workerVolumeEncryption,omitempty"`
+	UserDefinedSecondaryDisk *DiskConfigResp         `json:"secondaryStorageOption,omitempty"`
+}
+
+// DiskConfigResp response type for describing a disk configuration
+// swagger:model
+type DiskConfigResp struct {
+	Name  string `json:"name,omitempty"`
+	Count int
+	// the size of each individual device in GB
+	Size              int
+	DeviceType        string
+	RAIDConfiguration string
+	Profile           string `json:"profile,omitempty"`
 }
 
 type Lifecycle struct {

--- a/examples/container/V2containers/CreateClusterV2/main.go
+++ b/examples/container/V2containers/CreateClusterV2/main.go
@@ -28,10 +28,13 @@ func main() {
 	flag.StringVar(&SubnetID, "subnetid", "", "SubnetID")
 
 	var Name string
-	flag.StringVar(&Name, "Name", "bluemixV2Test", "Name")
+	flag.StringVar(&Name, "name", "bluemixV2Test", "Name")
 
 	var Zone string
-	flag.StringVar(&Zone, "Zone", "us-south-1", "Zone")
+	flag.StringVar(&Zone, "zone", "us-south-1", "Zone")
+
+	var SecondaryStorageOption string
+	flag.StringVar(&SecondaryStorageOption, "secondarystorage", "", "SecondaryStorageOption")
 
 	flag.Parse()
 	fmt.Println("[FLAG]KmsInstanceID: ", KmsInstanceID)
@@ -60,9 +63,9 @@ func main() {
 		WorkerPools: v2.WorkerPoolConfig{
 			CommonWorkerPoolConfig: v2.CommonWorkerPoolConfig{
 				DiskEncryption: true,
-				Flavor:         "bx2.16x64",
+				Flavor:         "bx2.4x16",
 				VpcID:          VpcID,
-				WorkerCount:    2,
+				WorkerCount:    1,
 				Zones: []v2.Zone{
 					{
 						ID:       Zone,
@@ -70,6 +73,7 @@ func main() {
 					},
 				},
 				WorkerVolumeEncryption: wve,
+				SecondaryStorageOption: SecondaryStorageOption,
 			},
 		},
 	}
@@ -95,5 +99,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println("out=", out)
+	fmt.Println("Cluster create request was successful")
+	fmt.Println("Response:", out)
 }

--- a/examples/container/V2containers/GetWorkerpoolV2/main.go
+++ b/examples/container/V2containers/GetWorkerpoolV2/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
 
@@ -12,6 +14,14 @@ import (
 )
 
 func main() {
+
+	var Cluster string
+	flag.StringVar(&Cluster, "cluster", "", "Cluster")
+
+	var WorkerPool string
+	flag.StringVar(&WorkerPool, "workerpool", "", "WorkerPool")
+
+	flag.Parse()
 
 	c := new(bluemix.Config)
 
@@ -28,16 +38,17 @@ func main() {
 
 	target := v2.ClusterTargetHeader{}
 
-	var cluster_id = "bm64u3ed02o93vv36hb0"
-	var workerpool_id = "bm64u3ed02o93vv36hb0-0dc20a0"
-
 	clusterClient, err := v2.New(sess)
 	if err != nil {
 		log.Fatal(err)
 	}
 	workerpoolAPI := clusterClient.WorkerPools()
 
-	out, err := workerpoolAPI.GetWorkerPool(cluster_id, workerpool_id, target)
-
-	fmt.Println("out=", out)
+	out, err := workerpoolAPI.GetWorkerPool(Cluster, WorkerPool, target)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Get workerpool request was successful")
+	json, _ := json.Marshal(out)
+	fmt.Println("Response:", string(json))
 }


### PR DESCRIPTION
this PR extends the cluster and workerpool operations with SecondaryStorageOption
https://containers.cloud.ibm.com/global/swagger-global-api/#/v2/getWorkerPool
https://containers.cloud.ibm.com/global/swagger-global-api/#/v2/vpcCreateCluster
https://containers.cloud.ibm.com/global/swagger-global-api/#/v2/vpcCreateWorkerPool

tested with the below examples:
```
CreateClusterV2 % go run main.go -vpcid <vpcid> -subnetid <subnetid> -secondarystorage 900gb.5iops-tier -zone <zoneid> -name zoza-test 
...
Cluster create request was successful
Response: {<clusterid>}

---------------------------

GetWorkerpoolV2 % go run main.go -cluster <clusterid> -workerpool default
...
Get workerpool request was successful
Response: {"flavor":"bx2.4x16","id":"<workerpoolid>","isolation":"public","labels":{"ibm-cloud.kubernetes.io/worker-pool-id":"<workerpoolid>"},"operatingSystem":"UBUNTU_18_64","lifecycle":{"actualState":"","desiredState":"active"},"vpcID":"<vpcid>","workerCount":1,"poolName":"default","provider":"vpc-gen2","zones":[{"id":"<zoneid>","workerCount":1,"subnets":[{"id":"<subnetid>","primary":true}]}],"secondaryStorageOption":{"name":"900gb.5iops-tier","Count":1,"Size":900,"DeviceType":"BLOCK","RAIDConfiguration":"none","profile":"5iops-tier"}}
```