### PR TITLE
List Addon Support

### DIFF
--- a/api/container/containerv1/addons.go
+++ b/api/container/containerv1/addons.go
@@ -6,28 +6,29 @@ import (
 	"github.com/IBM-Cloud/bluemix-go/client"
 )
 
-//AddOn ...
+// AddOn ...
 type AddOn struct {
-	AllowedUpgradeVersion []string    `json:"allowed_upgrade_versions,omitempty"`
-	Deprecated            bool        `json:"deprecated"`
-	HealthState           string      `json:"healthState,omitempty"`
-	HealthStatus          string      `json:"healthStatus,omitempty"`
-	MinKubeVersion        string      `json:"minKubeVersion,omitempty"`
-	MinOCPVersion         string      `json:"minOCPVersion,omitempty"`
-	Name                  string      `json:"name"`
-	Options               interface{} `json:"options,omitempty"`
-	SupportedKubeRange    string      `json:"supportedKubeRange,omitempty"`
-	TargetVersion         string      `json:"targetVersion,omitempty"`
-	Version               string      `json:"version,omitempty"`
-	VlanSpanningRequired  bool        `json:"vlan_spanning_required"`
+	AllowedUpgradeVersion  []string    `json:"allowed_upgrade_versions,omitempty"`
+	Deprecated             bool        `json:"deprecated"`
+	HealthState            string      `json:"healthState,omitempty"`
+	HealthStatus           string      `json:"healthStatus,omitempty"`
+	MinKubeVersion         string      `json:"minKubeVersion,omitempty"`
+	MinOCPVersion          string      `json:"minOCPVersion,omitempty"`
+	Name                   string      `json:"name"`
+	Options                interface{} `json:"options,omitempty"`
+	SupportedKubeRange     string      `json:"supportedKubeRange,omitempty"`
+	TargetVersion          string      `json:"targetVersion,omitempty"`
+	Version                string      `json:"version,omitempty"`
+	VlanSpanningRequired   bool        `json:"vlan_spanning_required"`
+	InstallOptionsTemplate interface{} `json:"installOptionsTemplate,omitempty"`
 }
 
-//GetAddOns ...
+// GetAddOns ...
 type GetAddOns struct {
 	AddonsList []AddOn `json:"addons"`
 }
 
-//ConfigureAddOns ...
+// ConfigureAddOns ...
 type ConfigureAddOns struct {
 	AddonsList []AddOn `json:"addons"`
 	Enable     bool    `json:"enable"`
@@ -40,10 +41,11 @@ type AddOnsResponse struct {
 	OrphanedAddons interface{} `json:"orphanedAddons,omitempty"`
 }
 
-//AddOns ...
+// AddOns ...
 type AddOns interface {
 	GetAddons(clusterName string, target ClusterTargetHeader) ([]AddOn, error)
 	ConfigureAddons(clusterName string, params *ConfigureAddOns, target ClusterTargetHeader) (AddOnsResponse, error)
+	ListAddons() ([]AddOn, error)
 }
 
 type addons struct {
@@ -56,11 +58,22 @@ func newAddOnsAPI(c *client.Client) AddOns {
 	}
 }
 
-//GetAddon ...
+// GetAddon ...
 func (r *addons) GetAddons(clusterName string, target ClusterTargetHeader) ([]AddOn, error) {
 	rawURL := fmt.Sprintf("/v1/clusters/%s/addons", clusterName)
 	addonsList := GetAddOns{}
 	_, err := r.client.Get(rawURL, &addonsList.AddonsList, target.ToMap())
+	if err != nil {
+		return addonsList.AddonsList, err
+	}
+
+	return addonsList.AddonsList, err
+}
+
+// ListAddon
+func (r *addons) ListAddons() ([]AddOn, error) {
+	addonsList := GetAddOns{}
+	_, err := r.client.Get("/v1/addons", &addonsList.AddonsList)
 	if err != nil {
 		return addonsList.AddonsList, err
 	}


### PR DESCRIPTION
List available add-ons that you can enable in a cluster. For each available add-on, the name, latest version, and minimum Kubernetes version required to run the add-on in a cluster are returned.

https://containers.cloud.ibm.com/global/swagger-global-api/#/util/GetAddons 