### PR TITLE
Containers API - cluster config update

### DIFF
--- a/api/container/containerv2/clusters.go
+++ b/api/container/containerv2/clusters.go
@@ -56,42 +56,46 @@ type Zone struct {
 
 // ClusterInfo ...
 type ClusterInfo struct {
-	CreatedDate               string        `json:"createdDate"`
-	DataCenter                string        `json:"dataCenter"`
-	ID                        string        `json:"id"`
-	Location                  string        `json:"location"`
-	Entitlement               string        `json:"entitlement"`
-	MasterKubeVersion         string        `json:"masterKubeVersion"`
-	Name                      string        `json:"name"`
-	Region                    string        `json:"region"`
-	ResourceGroupID           string        `json:"resourceGroup"`
-	State                     string        `json:"state"`
-	IsPaid                    bool          `json:"isPaid"`
-	Addons                    []Addon       `json:"addons"`
-	OwnerEmail                string        `json:"ownerEmail"`
-	Type                      string        `json:"type"`
-	TargetVersion             string        `json:"targetVersion"`
-	ServiceSubnet             string        `json:"serviceSubnet"`
-	ResourceGroupName         string        `json:"resourceGroupName"`
-	Provider                  string        `json:"provider"`
-	PodSubnet                 string        `json:"podSubnet"`
-	MultiAzCapable            bool          `json:"multiAzCapable"`
-	APIUser                   string        `json:"apiUser"`
-	ServerURL                 string        `json:"serverURL"`
-	MasterURL                 string        `json:"masterURL"`
-	MasterStatus              string        `json:"masterStatus"`
-	DisableAutoUpdate         bool          `json:"disableAutoUpdate"`
-	WorkerZones               []string      `json:"workerZones"`
-	Vpcs                      []string      `json:"vpcs"`
-	CRN                       string        `json:"crn"`
-	VersionEOS                string        `json:"versionEOS"`
-	ServiceEndpoints          Endpoints     `json:"serviceEndpoints"`
-	Lifecycle                 LifeCycleInfo `json:"lifecycle"`
-	WorkerCount               int           `json:"workerCount"`
-	Ingress                   IngresInfo    `json:"ingress"`
-	Features                  Feat          `json:"features"`
-	ImageSecurityEnabled      bool          `json:"imageSecurityEnabled"`
-	VirtualPrivateEndpointURL string        `json:"virtualPrivateEndpointURL"`
+	CreatedDate                   string        `json:"createdDate"`
+	DataCenter                    string        `json:"dataCenter"`
+	ID                            string        `json:"id"`
+	Location                      string        `json:"location"`
+	Entitlement                   string        `json:"entitlement"`
+	MasterKubeVersion             string        `json:"masterKubeVersion"`
+	Name                          string        `json:"name"`
+	Region                        string        `json:"region"`
+	ResourceGroupID               string        `json:"resourceGroup"`
+	State                         string        `json:"state"`
+	IsPaid                        bool          `json:"isPaid"`
+	Addons                        []Addon       `json:"addons"`
+	OwnerEmail                    string        `json:"ownerEmail"`
+	Type                          string        `json:"type"`
+	TargetVersion                 string        `json:"targetVersion"`
+	ServiceSubnet                 string        `json:"serviceSubnet"`
+	ResourceGroupName             string        `json:"resourceGroupName"`
+	Provider                      string        `json:"provider"`
+	PodSubnet                     string        `json:"podSubnet"`
+	MultiAzCapable                bool          `json:"multiAzCapable"`
+	APIUser                       string        `json:"apiUser"`
+	ServerURL                     string        `json:"serverURL"`
+	MasterURL                     string        `json:"masterURL"`
+	MasterStatus                  string        `json:"masterStatus"`
+	DisableAutoUpdate             bool          `json:"disableAutoUpdate"`
+	WorkerZones                   []string      `json:"workerZones"`
+	Vpcs                          []string      `json:"vpcs"`
+	CRN                           string        `json:"crn"`
+	VersionEOS                    string        `json:"versionEOS"`
+	ServiceEndpoints              Endpoints     `json:"serviceEndpoints"`
+	PrivateServiceEndpointEnabled bool          `json:"privateServiceEndpointEnabled"`
+	PrivateServiceEndpointURL     string        `json:"privateServiceEndpointURL"`
+	PublicServiceEndpointEnabled  bool          `json:"publicServiceEndpointEnabled"`
+	PublicServiceEndpointURL      string        `json:"publicServiceEndpointURL"`
+	Lifecycle                     LifeCycleInfo `json:"lifecycle"`
+	WorkerCount                   int           `json:"workerCount"`
+	Ingress                       IngresInfo    `json:"ingress"`
+	Features                      Feat          `json:"features"`
+	ImageSecurityEnabled          bool          `json:"imageSecurityEnabled"`
+	VirtualPrivateEndpointURL     string        `json:"virtualPrivateEndpointURL"`
 }
 type Feat struct {
 	KeyProtectEnabled bool `json:"keyProtectEnabled"`
@@ -243,6 +247,21 @@ func (r *clusters) FindWithOutShowResourcesCompatible(name string, target Cluste
 	if cluster.ServerURL == "" {
 		cluster.ServerURL = cluster.MasterURL
 	}
+
+	// Workaround for ServiceEndpoints: armada-api returns different structure for different providers (classic vs VPC)
+	if !cluster.ServiceEndpoints.PrivateServiceEndpointEnabled && cluster.PrivateServiceEndpointEnabled {
+		cluster.ServiceEndpoints.PrivateServiceEndpointEnabled = cluster.PrivateServiceEndpointEnabled
+	}
+	if cluster.ServiceEndpoints.PrivateServiceEndpointURL == "" && cluster.PrivateServiceEndpointURL != "" {
+		cluster.ServiceEndpoints.PrivateServiceEndpointURL = cluster.PrivateServiceEndpointURL
+	}
+	if !cluster.ServiceEndpoints.PublicServiceEndpointEnabled && cluster.PublicServiceEndpointEnabled {
+		cluster.ServiceEndpoints.PublicServiceEndpointEnabled = cluster.PublicServiceEndpointEnabled
+	}
+	if cluster.ServiceEndpoints.PublicServiceEndpointURL == "" && cluster.PublicServiceEndpointURL != "" {
+		cluster.ServiceEndpoints.PublicServiceEndpointURL = cluster.PublicServiceEndpointURL
+	}
+
 	return cluster, err
 }
 

--- a/api/container/containerv2/clusters.go
+++ b/api/container/containerv2/clusters.go
@@ -56,41 +56,42 @@ type Zone struct {
 
 // ClusterInfo ...
 type ClusterInfo struct {
-	CreatedDate          string        `json:"createdDate"`
-	DataCenter           string        `json:"dataCenter"`
-	ID                   string        `json:"id"`
-	Location             string        `json:"location"`
-	Entitlement          string        `json:"entitlement"`
-	MasterKubeVersion    string        `json:"masterKubeVersion"`
-	Name                 string        `json:"name"`
-	Region               string        `json:"region"`
-	ResourceGroupID      string        `json:"resourceGroup"`
-	State                string        `json:"state"`
-	IsPaid               bool          `json:"isPaid"`
-	Addons               []Addon       `json:"addons"`
-	OwnerEmail           string        `json:"ownerEmail"`
-	Type                 string        `json:"type"`
-	TargetVersion        string        `json:"targetVersion"`
-	ServiceSubnet        string        `json:"serviceSubnet"`
-	ResourceGroupName    string        `json:"resourceGroupName"`
-	Provider             string        `json:"provider"`
-	PodSubnet            string        `json:"podSubnet"`
-	MultiAzCapable       bool          `json:"multiAzCapable"`
-	APIUser              string        `json:"apiUser"`
-	ServerURL            string        `json:"serverURL"`
-	MasterURL            string        `json:"masterURL"`
-	MasterStatus         string        `json:"masterStatus"`
-	DisableAutoUpdate    bool          `json:"disableAutoUpdate"`
-	WorkerZones          []string      `json:"workerZones"`
-	Vpcs                 []string      `json:"vpcs"`
-	CRN                  string        `json:"crn"`
-	VersionEOS           string        `json:"versionEOS"`
-	ServiceEndpoints     Endpoints     `json:"serviceEndpoints"`
-	Lifecycle            LifeCycleInfo `json:"lifecycle"`
-	WorkerCount          int           `json:"workerCount"`
-	Ingress              IngresInfo    `json:"ingress"`
-	Features             Feat          `json:"features"`
-	ImageSecurityEnabled bool          `json:"imageSecurityEnabled"`
+	CreatedDate               string        `json:"createdDate"`
+	DataCenter                string        `json:"dataCenter"`
+	ID                        string        `json:"id"`
+	Location                  string        `json:"location"`
+	Entitlement               string        `json:"entitlement"`
+	MasterKubeVersion         string        `json:"masterKubeVersion"`
+	Name                      string        `json:"name"`
+	Region                    string        `json:"region"`
+	ResourceGroupID           string        `json:"resourceGroup"`
+	State                     string        `json:"state"`
+	IsPaid                    bool          `json:"isPaid"`
+	Addons                    []Addon       `json:"addons"`
+	OwnerEmail                string        `json:"ownerEmail"`
+	Type                      string        `json:"type"`
+	TargetVersion             string        `json:"targetVersion"`
+	ServiceSubnet             string        `json:"serviceSubnet"`
+	ResourceGroupName         string        `json:"resourceGroupName"`
+	Provider                  string        `json:"provider"`
+	PodSubnet                 string        `json:"podSubnet"`
+	MultiAzCapable            bool          `json:"multiAzCapable"`
+	APIUser                   string        `json:"apiUser"`
+	ServerURL                 string        `json:"serverURL"`
+	MasterURL                 string        `json:"masterURL"`
+	MasterStatus              string        `json:"masterStatus"`
+	DisableAutoUpdate         bool          `json:"disableAutoUpdate"`
+	WorkerZones               []string      `json:"workerZones"`
+	Vpcs                      []string      `json:"vpcs"`
+	CRN                       string        `json:"crn"`
+	VersionEOS                string        `json:"versionEOS"`
+	ServiceEndpoints          Endpoints     `json:"serviceEndpoints"`
+	Lifecycle                 LifeCycleInfo `json:"lifecycle"`
+	WorkerCount               int           `json:"workerCount"`
+	Ingress                   IngresInfo    `json:"ingress"`
+	Features                  Feat          `json:"features"`
+	ImageSecurityEnabled      bool          `json:"imageSecurityEnabled"`
+	VirtualPrivateEndpointURL string        `json:"virtualPrivateEndpointURL"`
 }
 type Feat struct {
 	KeyProtectEnabled bool `json:"keyProtectEnabled"`
@@ -355,7 +356,7 @@ func (r *clusters) GetClusterConfigDetail(name, dir string, admin bool, target C
 		if yamlConfig, err = ioutil.ReadFile(kubeyml); err != nil {
 			return clusterkey, err
 		}
-		yamlConfig, err = r.FetchOCTokenForKubeConfig(yamlConfig, &clusterInfo, clusterInfo.IsStagingSatelliteCluster())
+		yamlConfig, err = r.FetchOCTokenForKubeConfig(yamlConfig, &clusterInfo, clusterInfo.IsStagingSatelliteCluster(), endpointType)
 		if err != nil {
 			return clusterkey, err
 		}
@@ -511,7 +512,7 @@ func (r *clusters) StoreConfigDetail(name, dir string, admin, createCalicoConfig
 		if yamlConfig, err = ioutil.ReadFile(kubeconfigFileName); err != nil {
 			return "", clusterkey, err
 		}
-		yamlConfig, err = r.FetchOCTokenForKubeConfig(yamlConfig, &clusterInfo, clusterInfo.IsStagingSatelliteCluster())
+		yamlConfig, err = r.FetchOCTokenForKubeConfig(yamlConfig, &clusterInfo, clusterInfo.IsStagingSatelliteCluster(), endpointType)
 		if err != nil {
 			return "", clusterkey, err
 		}

--- a/api/container/containerv2/openshift.go
+++ b/api/container/containerv2/openshift.go
@@ -192,8 +192,6 @@ func (r *clusters) FetchOCTokenForKubeConfig(kubecfg []byte, cMeta *ClusterInfo,
 	users = append(users, newUser)
 	cfg["users"] = users
 
-	cfg["current-context"] = ccontext
-
 	bytes, err := yaml.Marshal(cfg)
 	if err != nil {
 		return kubecfg, err

--- a/api/container/containerv2/openshift_test.go
+++ b/api/container/containerv2/openshift_test.go
@@ -1,0 +1,145 @@
+package containerv2
+
+/*******************************************************************************
+ * IBM Confidential
+ * OCO Source Materials
+ * IBM Cloud Schematics
+ * (C) Copyright IBM Corp. 2023 All Rights Reserved.
+ * The source code for this program is not  published or otherwise divested of
+ * its trade secrets, irrespective of what has been deposited with
+ * the U.S. Copyright Office.
+ ******************************************************************************/
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	OauthPrivateEndpoint         = "https://c200-e.private.test.containers.cloud.ibm.com:31579/.well-known/oauth-authorization-server"
+	OauthVirtualPrivateEndpoint  = "https://clusterID.vpe.private.test.containers.cloud.ibm.com:31579/.well-known/oauth-authorization-server"
+	ServerPrivateEndpoint        = "https://c200.private.test.containers.cloud.ibm.com:31580"
+	ServerVirtualPrivateEndpoint = "https://clusterID.vpe.private.test.containers.cloud.ibm.com:31580"
+)
+
+var _ = Describe("Openshift utils", func() {
+	Describe("Openshift related AuthEndpoint modification", func() {
+		Context("AuthEndpoint is configured with private", func() {
+			It("should not change it", func() {
+				clusterInfo := ClusterInfo{
+					ServiceEndpoints: Endpoints{
+						PrivateServiceEndpointEnabled: true,
+						PrivateServiceEndpointURL:     ServerPrivateEndpoint,
+					},
+					VirtualPrivateEndpointURL: ServerVirtualPrivateEndpoint,
+				}
+				authServer, err := reconfigureAuthorizationEndpoint(OauthPrivateEndpoint, "private", &clusterInfo)
+				Expect(authServer).ShouldNot(BeEmpty())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(authServer).Should(Equal(OauthPrivateEndpoint))
+			})
+		})
+		Context("AuthEndpoint is configured with VPE", func() {
+			It("should not change it", func() {
+				clusterInfo := ClusterInfo{
+					ServiceEndpoints: Endpoints{
+						PrivateServiceEndpointEnabled: true,
+						PrivateServiceEndpointURL:     ServerPrivateEndpoint,
+					},
+					VirtualPrivateEndpointURL: ServerVirtualPrivateEndpoint,
+				}
+				authServer, err := reconfigureAuthorizationEndpoint(OauthVirtualPrivateEndpoint, VirtualPrivateEndpoint, &clusterInfo)
+				Expect(authServer).ShouldNot(BeEmpty())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(authServer).Should(Equal(OauthVirtualPrivateEndpoint))
+			})
+		})
+		Context("AuthEndpoint is configured with Private", func() {
+			It("should replace to VPE - case for ROKS 4.12", func() {
+				clusterInfo := ClusterInfo{
+					ServiceEndpoints: Endpoints{
+						PrivateServiceEndpointEnabled: true,
+						PrivateServiceEndpointURL:     ServerPrivateEndpoint,
+					},
+					VirtualPrivateEndpointURL: ServerVirtualPrivateEndpoint,
+				}
+				authServer, err := reconfigureAuthorizationEndpoint(OauthPrivateEndpoint, VirtualPrivateEndpoint, &clusterInfo)
+				Expect(authServer).ShouldNot(BeEmpty())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(authServer).Should(Equal(OauthVirtualPrivateEndpoint))
+			})
+		})
+		Context("AuthEndpoint is configured with VPE", func() {
+			It("should replace to Private - case for ROKS 4.13", func() {
+				clusterInfo := ClusterInfo{
+					ServiceEndpoints: Endpoints{
+						PrivateServiceEndpointEnabled: true,
+						PrivateServiceEndpointURL:     ServerPrivateEndpoint,
+					},
+					VirtualPrivateEndpointURL: ServerVirtualPrivateEndpoint,
+				}
+				authServer, err := reconfigureAuthorizationEndpoint(OauthVirtualPrivateEndpoint, PrivateServiceEndpoint, &clusterInfo)
+				Expect(authServer).ShouldNot(BeEmpty())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(authServer).Should(Equal(OauthPrivateEndpoint))
+			})
+		})
+		Context("AuthEndpoint is empty", func() {
+			It("should shall fail", func() {
+				clusterInfo := ClusterInfo{
+					ServiceEndpoints: Endpoints{
+						PrivateServiceEndpointEnabled: true,
+						PrivateServiceEndpointURL:     ServerPrivateEndpoint,
+					},
+					VirtualPrivateEndpointURL: ServerVirtualPrivateEndpoint,
+				}
+				authServer, err := reconfigureAuthorizationEndpoint("", PrivateEndpointDNS, &clusterInfo)
+				Expect(authServer).Should(BeEmpty())
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+		Context("AuthEndpoint is configured with private - request to change", func() {
+			It("should fail as Virtual Private Endpoint URL is empty", func() {
+				clusterInfo := ClusterInfo{
+					ServiceEndpoints: Endpoints{
+						PrivateServiceEndpointEnabled: false,
+						PrivateServiceEndpointURL:     "",
+					},
+					VirtualPrivateEndpointURL: "",
+				}
+				authServer, err := reconfigureAuthorizationEndpoint(OauthPrivateEndpoint, VirtualPrivateEndpoint, &clusterInfo)
+				Expect(authServer).Should(BeEmpty())
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+		Context("AuthEndpoint is configured with VPE - request to change", func() {
+			It("should fail as Private Service Endpoint URL is empty", func() {
+				clusterInfo := ClusterInfo{
+					ServiceEndpoints: Endpoints{
+						PrivateServiceEndpointEnabled: false,
+						PrivateServiceEndpointURL:     "",
+					},
+					VirtualPrivateEndpointURL: ServerVirtualPrivateEndpoint,
+				}
+				authServer, err := reconfigureAuthorizationEndpoint(OauthVirtualPrivateEndpoint, PrivateServiceEndpoint, &clusterInfo)
+				Expect(authServer).Should(BeEmpty())
+				Expect(err).Should(HaveOccurred())
+			})
+		})
+		Context("AuthEndpoint is configured with VPE", func() {
+			It("should not change it as endpointType is empty", func() {
+				clusterInfo := ClusterInfo{
+					ServiceEndpoints: Endpoints{
+						PrivateServiceEndpointEnabled: false,
+						PrivateServiceEndpointURL:     "",
+					},
+					VirtualPrivateEndpointURL: ServerVirtualPrivateEndpoint,
+				}
+				authServer, err := reconfigureAuthorizationEndpoint(OauthVirtualPrivateEndpoint, "", &clusterInfo)
+				Expect(authServer).NotTo(BeEmpty())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(authServer).Should(Equal(OauthVirtualPrivateEndpoint))
+			})
+		})
+	})
+})

--- a/api/container/containerv2/openshift_test.go
+++ b/api/container/containerv2/openshift_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Openshift utils", func() {
 			It("should fail as Private Service Endpoint URL is empty", func() {
 				clusterInfo := ClusterInfo{
 					ServiceEndpoints: Endpoints{
-						PrivateServiceEndpointEnabled: false,
+						PrivateServiceEndpointEnabled: true,
 						PrivateServiceEndpointURL:     "",
 					},
 					VirtualPrivateEndpointURL: ServerVirtualPrivateEndpoint,


### PR DESCRIPTION
- in case of Openshift, honor the endpoint type when generating the token based kubeconfig

Test: ROKS 4.12 on VPC (Public Service Endpoint is disabled)
1. Both configs contain the Private Service Endpoint - as that is the default for the cluster.
```
➜ go run main.go -clustername ck6414bl0a61qv1bo690 -path /Users/adam/terraform/terraform_output
➜ cat /Users/adam/terraform/terraform_output/6189e52cfb76e60b485d8d90acc513b9337734242accf8dbfbbb943f777f92d8_ck6414bl0a61qv1bo690_k8sconfig/config.yml      
apiVersion: v1
clusters:
- cluster:
    server: https://c108-e.private.eu-gb.containers.cloud.ibm.com:31579
  name: console-vpe-412/ck6414bl0a61qv1bo690
- cluster:
    server: https://c108-e.private.eu-gb.containers.cloud.ibm.com:31579
  name: c108-e-private-eu-gb-containers-cloud-ibm-com:31579
contexts:
- context:
    cluster: console-vpe-412/ck6414bl0a61qv1bo690
    namespace: default
    user: ""
  name: console-vpe-412/ck6414bl0a61qv1bo690
- context:
    cluster: c108-e-private-eu-gb-containers-cloud-ibm-com:31579
    namespace: default
    user: IAM#iksroch2@us.ibm.com/c108-e-private-eu-gb-containers-cloud-ibm-com:31579
  name: default/c108-e-private-eu-gb-containers-cloud-ibm-com:31579/IAM#iksroch2@us.ibm.com
current-context: default/c108-e-private-eu-gb-containers-cloud-ibm-com:31579/IAM#iksroch2@us.ibm.com
kind: Config
preferences: {}
users:
- name: IAM#iksroch2@us.ibm.com/c108-e-private-eu-gb-containers-cloud-ibm-com:31579
  user:
    token: sha256~XXXXXXXX
```

2.  Both configs contain the Virtual Privat Endpoint - as that is configured for the command
```
➜ go run main.go -clustername ck6414bl0a61qv1bo690 -path /Users/adam/terraform/terraform_output -endpoint vpe
➜ cat /Users/adam/terraform/terraform_output/6189e52cfb76e60b485d8d90acc513b9337734242accf8dbfbbb943f777f92d8_ck6414bl0a61qv1bo690_k8sconfig/config.yml
apiVersion: v1
clusters:
- cluster:
    server: https://ck6414bl0a61qv1bo690.vpe.private.eu-gb.containers.cloud.ibm.com:31579
  name: console-vpe-412/ck6414bl0a61qv1bo690
- cluster:
    server: https://ck6414bl0a61qv1bo690.vpe.private.eu-gb.containers.cloud.ibm.com:31579
  name: ck6414bl0a61qv1bo690-vpe-private-eu-gb-containers-cloud-ibm-com:31579
contexts:
- context:
    cluster: console-vpe-412/ck6414bl0a61qv1bo690
    namespace: default
    user: ""
  name: console-vpe-412/ck6414bl0a61qv1bo690
- context:
    cluster: ck6414bl0a61qv1bo690-vpe-private-eu-gb-containers-cloud-ibm-com:31579
    namespace: default
    user: IAM#iksroch2@us.ibm.com/ck6414bl0a61qv1bo690-vpe-private-eu-gb-containers-cloud-ibm-com:31579
  name: default/ck6414bl0a61qv1bo690-vpe-private-eu-gb-containers-cloud-ibm-com:31579/IAM#iksroch2@us.ibm.com
current-context: default/ck6414bl0a61qv1bo690-vpe-private-eu-gb-containers-cloud-ibm-com:31579/IAM#iksroch2@us.ibm.com
kind: Config
preferences: {}
users:
- name: IAM#iksroch2@us.ibm.com/ck6414bl0a61qv1bo690-vpe-private-eu-gb-containers-cloud-ibm-com:31579
  user:
    token: sha256~XXXXXX
```


