### PR TITLE
Fix return values of cluster_config 

### DIFF
--- a/api/container/containerv2/clusters.go
+++ b/api/container/containerv2/clusters.go
@@ -375,7 +375,7 @@ func (r *clusters) GetClusterConfigDetail(name, dir string, admin bool, target C
 		if yamlConfig, err = ioutil.ReadFile(kubeyml); err != nil {
 			return clusterkey, err
 		}
-		yamlConfig, err = r.FetchOCTokenForKubeConfig(yamlConfig, &clusterInfo, clusterInfo.IsStagingSatelliteCluster(), endpointType)
+		yamlConfig, clusterkey.Host, err = r.FetchOCTokenForKubeConfig(yamlConfig, &clusterInfo, clusterInfo.IsStagingSatelliteCluster(), endpointType)
 		if err != nil {
 			return clusterkey, err
 		}
@@ -394,9 +394,6 @@ func (r *clusters) GetClusterConfigDetail(name, dir string, admin bool, target C
 			if strings.HasPrefix(usr.Name, "IAM") {
 				clusterkey.Token = usr.User.Token
 			}
-		}
-		if len(openshiftyaml.Clusters) != 0 {
-			clusterkey.Host = openshiftyaml.Clusters[0].Cluster.Server
 		}
 		clusterkey.ClusterCACertificate = ""
 
@@ -531,7 +528,7 @@ func (r *clusters) StoreConfigDetail(name, dir string, admin, createCalicoConfig
 		if yamlConfig, err = ioutil.ReadFile(kubeconfigFileName); err != nil {
 			return "", clusterkey, err
 		}
-		yamlConfig, err = r.FetchOCTokenForKubeConfig(yamlConfig, &clusterInfo, clusterInfo.IsStagingSatelliteCluster(), endpointType)
+		yamlConfig, clusterkey.Host, err = r.FetchOCTokenForKubeConfig(yamlConfig, &clusterInfo, clusterInfo.IsStagingSatelliteCluster(), endpointType)
 		if err != nil {
 			return "", clusterkey, err
 		}
@@ -550,9 +547,6 @@ func (r *clusters) StoreConfigDetail(name, dir string, admin, createCalicoConfig
 			if strings.HasPrefix(usr.Name, "IAM") {
 				clusterkey.Token = usr.User.Token
 			}
-		}
-		if len(openshiftyaml.Clusters) != 0 {
-			clusterkey.Host = openshiftyaml.Clusters[0].Cluster.Server
 		}
 		clusterkey.ClusterCACertificate = ""
 


### PR DESCRIPTION
- in case Openshift, the clusterHost ouptut value should be set with same value as the generated kubeconfig with FetchOCTokenForKubeConfig
- the ealier solution was added the host from the first kubeconfig context (got from Containers API)

Related to https://github.com/IBM-Cloud/terraform-provider-ibm/issues/4861
