### PR TITLE
Remove references for creating free clusters, no longer supported

### DIFF
--- a/api/container/containerv1/clusters_test.go
+++ b/api/container/containerv1/clusters_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Clusters", func() {
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest(http.MethodPost, "/v1/clusters"),
-						ghttp.VerifyJSON(`{"GatewayEnabled": false,"defaultWorkerPoolName": "","disableAutoUpdate": false,"podSubnet": "","serviceSubnet": "","dataCenter":"dal10","isolation":"","machineType":"free","name":"testservice","privateVlan":"vlan","publicVlan":"vlan","workerNum":1,"noSubnet":false,"masterVersion":"1.8.1","prefix":"worker","diskEncryption": false,"privateSeviceEndpoint": false,"publicServiceEndpoint": false,"defaultWorkerPoolEntitlement": ""}
+						ghttp.VerifyJSON(`{"GatewayEnabled": false,"defaultWorkerPoolName": "","disableAutoUpdate": false,"podSubnet": "","serviceSubnet": "","dataCenter":"dal10","isolation":"","machineType":"u2c.2x4","name":"testservice","privateVlan":"vlan","publicVlan":"vlan","workerNum":1,"noSubnet":false,"masterVersion":"1.8.1","prefix":"worker","diskEncryption": false,"privateSeviceEndpoint": false,"publicServiceEndpoint": false,"defaultWorkerPoolEntitlement": ""}
 `),
 						ghttp.RespondWith(http.StatusInternalServerError, `Failed to create cluster`),
 					),
@@ -106,7 +106,7 @@ var _ = Describe("Clusters", func() {
 
 			It("should return error during cluster creation", func() {
 				params := ClusterCreateRequest{
-					Name: "testservice", Datacenter: "dal10", MachineType: "free", PublicVlan: "vlan", PrivateVlan: "vlan", MasterVersion: "1.8.1", Prefix: "worker", WorkerNum: 1,
+					Name: "testservice", Datacenter: "dal10", MachineType: "u2c.2x4", PublicVlan: "vlan", PrivateVlan: "vlan", MasterVersion: "1.8.1", Prefix: "worker", WorkerNum: 1,
 				}
 				target := ClusterTargetHeader{
 					OrgID:     "abc",

--- a/api/container/containerv1/workers_test.go
+++ b/api/container/containerv1/workers_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Workers", func() {
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest(http.MethodGet, "/v1/workers/abc-123-def-ghi"),
-						ghttp.RespondWith(http.StatusOK, `{"ErrorMessage":"","Isolation":"","MachineType":"free","KubeVersion":"","PrivateIP":"","PublicIP":"","PrivateVlan":"vlan","PublicVlan":"vlan","state":"normal","status":"ready"}`),
+						ghttp.RespondWith(http.StatusOK, `{"ErrorMessage":"","Isolation":"","MachineType":"u2c.2x4","KubeVersion":"","PrivateIP":"","PublicIP":"","PrivateVlan":"vlan","PublicVlan":"vlan","state":"normal","status":"ready"}`),
 					),
 				)
 			})
@@ -125,7 +125,7 @@ var _ = Describe("Workers", func() {
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest(http.MethodGet, "/v1/clusters/myCluster/workers"),
-						ghttp.RespondWith(http.StatusOK, `[{"ErrorMessage":"","Isolation":"","MachineType":"free","KubeVersion":"","PrivateIP":"","PublicIP":"","PrivateVlan":"vlan","PublicVlan":"vlan","state":"normal","status":"ready"}]`),
+						ghttp.RespondWith(http.StatusOK, `[{"ErrorMessage":"","Isolation":"","MachineType":"u2c.2x4","KubeVersion":"","PrivateIP":"","PublicIP":"","PrivateVlan":"vlan","PublicVlan":"vlan","state":"normal","status":"ready"}]`),
 					),
 				)
 			})
@@ -178,7 +178,7 @@ var _ = Describe("Workers", func() {
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest(http.MethodGet, "/v1/clusters/myCluster/workers"),
-						ghttp.RespondWith(http.StatusOK, `[{"ErrorMessage":"","Isolation":"","MachineType":"free","KubeVersion":"","PrivateIP":"","PublicIP":"","PrivateVlan":"vlan","PublicVlan":"vlan","state":"normal","status":"ready"}]`),
+						ghttp.RespondWith(http.StatusOK, `[{"ErrorMessage":"","Isolation":"","MachineType":"u2c.2x4","KubeVersion":"","PrivateIP":"","PublicIP":"","PrivateVlan":"vlan","PublicVlan":"vlan","state":"normal","status":"ready"}]`),
 					),
 				)
 			})

--- a/examples/container/custom_container_endpoint/main.go
+++ b/examples/container/custom_container_endpoint/main.go
@@ -18,7 +18,7 @@ import (
 var clusterInfo = v1.ClusterCreateRequest{
 	Name:        "my_cluster",
 	Datacenter:  "dal10",
-	MachineType: "free",
+	MachineType: "u2c.2x4",
 	WorkerNum:   1,
 	PrivateVlan: "vlan",
 	PublicVlan:  "vlan",


### PR DESCRIPTION
Updated UTs/code examples/docs to remove free cluster creations.
(by searching all instances where free/lite is used)