### PR TITLE
add masterHealth field to cluster struct

### DIFF
--- a/api/container/containerv2/clusters.go
+++ b/api/container/containerv2/clusters.go
@@ -80,6 +80,7 @@ type ClusterInfo struct {
 	MultiAzCapable                bool          `json:"multiAzCapable"`
 	APIUser                       string        `json:"apiUser"`
 	ServerURL                     string        `json:"serverURL"`
+	MasterHealth                  string        `json:"masterHealth"`
 	MasterURL                     string        `json:"masterURL"`
 	MasterStatus                  string        `json:"masterStatus"`
 	DisableAutoUpdate             bool          `json:"disableAutoUpdate"`

--- a/examples/container/V2containers/GetClusterV2/main.go
+++ b/examples/container/V2containers/GetClusterV2/main.go
@@ -16,7 +16,7 @@ func main() {
 
 	c := new(bluemix.Config)
 
-	trace.Logger = trace.NewLogger("true")
+	trace.Logger = trace.NewLogger("false")
 
 	target := v2.ClusterTargetHeader{}
 
@@ -35,5 +35,5 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println("ouyt=", out)
+	fmt.Printf("%+v\n", out)
 }


### PR DESCRIPTION
Using the API `global/v2/getCluster?=cluster<id>&v1-compatible` there are different return values depending on the provider.

For VPC clusters, masterHealth (and other master fields) can be checked in the lifecycle resource. Classic clusters don't have this resource and instead call masterHealth directly.

Downstream, the observability terraform provider needs to be able to check masterHealth to confirm the cluster is ready to deploy. So this PR is adding masterHealth to the cluster struct.