### PR TITLE
Add new SetWorkerPoolOperatingSystem api

### DIFF
--- a/api/container/containerv2/worker_pool.go
+++ b/api/container/containerv2/worker_pool.go
@@ -194,7 +194,7 @@ func (w *workerpool) UpdateWorkerPoolLabels(setWorkerPoolLabelsRequest SetWorker
 
 // SetWorkerPoolOperatingSystem calls the API to set the workerpool operating system.
 func (w *workerpool) SetWorkerPoolOperatingSystem(setWorkerPoolOperatingSystemRequest SetWorkerPoolOperatingSystem, target ClusterTargetHeader) error {
-	// Make the request, don't care about return value
+	// Returns 202 without body
 	_, err := w.client.Post("/v2/setWorkerPoolOperatingSystem", setWorkerPoolOperatingSystemRequest, nil, target.ToMap())
 	return err
 }

--- a/api/container/containerv2/worker_pool.go
+++ b/api/container/containerv2/worker_pool.go
@@ -108,6 +108,12 @@ type ResizeWorkerPoolReq struct {
 	Workerpool string `json:"workerpool"`
 }
 
+type SetWorkerPoolOperatingSystem struct {
+	Cluster         string `json:"cluster"`
+	WorkerPool      string `json:"workerPool"`
+	OperatingSystem string `json:"operatingSystem"`
+}
+
 // Workers ...
 type WorkerPool interface {
 	CreateWorkerPool(workerPoolReq WorkerPoolRequest, target ClusterTargetHeader) (WorkerPoolResponse, error)
@@ -118,6 +124,7 @@ type WorkerPool interface {
 	UpdateWorkerPoolTaints(taintRequest WorkerPoolTaintRequest, target ClusterTargetHeader) error
 	ResizeWorkerPool(resizeWorkerPoolReq ResizeWorkerPoolReq, target ClusterTargetHeader) error
 	UpdateWorkerPoolLabels(setWorkerPoolLabelsRequest SetWorkerPoolLabelsRequest, target ClusterTargetHeader) error
+	SetWorkerPoolOperatingSystem(setWorkerPoolOperatingSystemRequest SetWorkerPoolOperatingSystem, target ClusterTargetHeader) error
 }
 
 type workerpool struct {
@@ -182,5 +189,12 @@ func (w *workerpool) ResizeWorkerPool(resizeWorkerPoolReq ResizeWorkerPoolReq, t
 func (w *workerpool) UpdateWorkerPoolLabels(setWorkerPoolLabelsRequest SetWorkerPoolLabelsRequest, target ClusterTargetHeader) error {
 	// Make the request, don't care about return value
 	_, err := w.client.Post("/v2/setWorkerPoolLabels", setWorkerPoolLabelsRequest, nil, target.ToMap())
+	return err
+}
+
+// SetWorkerPoolOperatingSystem calls the API to set the workerpool operating system.
+func (w *workerpool) SetWorkerPoolOperatingSystem(setWorkerPoolOperatingSystemRequest SetWorkerPoolOperatingSystem, target ClusterTargetHeader) error {
+	// Make the request, don't care about return value
+	_, err := w.client.Post("/v2/setWorkerPoolOperatingSystem", setWorkerPoolOperatingSystemRequest, nil, target.ToMap())
 	return err
 }

--- a/api/container/containerv2/worker_pool_test.go
+++ b/api/container/containerv2/worker_pool_test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	bluemix "github.com/IBM-Cloud/bluemix-go"
+	"github.com/IBM-Cloud/bluemix-go"
 	"github.com/IBM-Cloud/bluemix-go/client"
 	bluemixHttp "github.com/IBM-Cloud/bluemix-go/http"
 	"github.com/IBM-Cloud/bluemix-go/session"
@@ -652,6 +652,54 @@ var _ = Describe("workerpools", func() {
 					err := newWorkerPool(server.URL()).UpdateWorkerPoolLabels(params, target)
 					Expect(err).ToNot(HaveOccurred())
 				})
+			})
+		})
+	})
+
+	Describe("SetWorkerPoolOperatingSystem", func() {
+		Context("When setting workerpool operating system is successful", func() {
+			BeforeEach(func() {
+				server = ghttp.NewServer()
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPost, "/v2/setWorkerPoolOperatingSystem"),
+						ghttp.VerifyJSON(`{"cluster":"bm64u3ed02o93vv36hb0","workerPool":"mywork211","operatingSystem":"UBUNTU_24_64"}`),
+					),
+				)
+			})
+			It("should resize Workerpool in a cluster", func() {
+				target := ClusterTargetHeader{}
+				params := SetWorkerPoolOperatingSystem{
+					Cluster:         "bm64u3ed02o93vv36hb0",
+					WorkerPool:      "mywork211",
+					OperatingSystem: "UBUNTU_24_64",
+				}
+				err := newWorkerPool(server.URL()).SetWorkerPoolOperatingSystem(params, target)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		Context("When setting workerpool operating system is unsuccessful", func() {
+			BeforeEach(func() {
+				server = ghttp.NewServer()
+				server.SetAllowUnhandledRequests(true)
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodPost, "/v2/setWorkerPoolOperatingSystem"),
+						ghttp.VerifyJSON(`{"cluster":"bm64u3ed02o93vv36hb0","workerPool":"mywork211","operatingSystem":"UBUNTU_24_64"}`),
+						ghttp.RespondWith(http.StatusInternalServerError, `Failed to set operating system`),
+					),
+				)
+			})
+
+			It("should return error during resizing workerpool", func() {
+				params := SetWorkerPoolOperatingSystem{
+					Cluster:         "bm64u3ed02o93vv36hb0",
+					WorkerPool:      "mywork211",
+					OperatingSystem: "UBUNTU_24_64",
+				}
+				target := ClusterTargetHeader{}
+				err := newWorkerPool(server.URL()).SetWorkerPoolOperatingSystem(params, target)
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/api/container/containerv2/workers.go
+++ b/api/container/containerv2/workers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/IBM-Cloud/bluemix-go/client"
 )
 
-//Worker ...
+// Worker ...
 type Worker struct {
 	Billing           string `json:"billing,omitempty"`
 	HostID            string `json:"dedicatedHostId,omitempty"`
@@ -15,7 +15,7 @@ type Worker struct {
 	ID                string `json:"id"`
 	KubeVersion       KubeDetails
 	Location          string          `json:"location"`
-	PoolID            string          `json:"poolid"`
+	PoolID            string          `json:"poolID"`
 	PoolName          string          `json:"poolName"`
 	LifeCycle         WorkerLifeCycle `json:"lifecycle"`
 	Health            HealthStatus    `json:"health"`
@@ -34,14 +34,15 @@ type HealthStatus struct {
 	State   string `json:"state"`
 }
 type WorkerLifeCycle struct {
-	ReasonForDelete    string `json:"reasonForDelete"`
-	ActualState        string `json:"actualState"`
-	DesiredState       string `json:"desiredState"`
-	Message            string `json:"message"`
-	MessageDate        string `json:"messageDate"`
-	MessageDetails     string `json:"messageDetails"`
-	MessageDetailsDate string `json:"messageDetailsDate"`
-	PendingOperation   string `json:"pendingOperation"`
+	ReasonForDelete       string `json:"reasonForDelete"`
+	ActualState           string `json:"actualState"`
+	DesiredState          string `json:"desiredState"`
+	Message               string `json:"message"`
+	MessageDate           string `json:"messageDate"`
+	MessageDetails        string `json:"messageDetails"`
+	MessageDetailsDate    string `json:"messageDetailsDate"`
+	PendingOperation      string `json:"pendingOperation"`
+	ActualOperatingSystem string `json:"actualOperatingSystem"`
 }
 
 type Network struct {
@@ -86,10 +87,11 @@ type VolumeRequest struct {
 	Worker             string `json:"worker"`
 }
 
-//Workers ...
+// Workers ...
 type Workers interface {
 	ListByWorkerPool(clusterIDOrName, workerPoolIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error)
 	ListWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error)
+	ListClassicWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error)
 	Get(clusterIDOrName, workerID string, target ClusterTargetHeader) (Worker, error)
 	ReplaceWokerNode(clusterIDOrName, workerID string, target ClusterTargetHeader) (string, error)
 	ListStorageAttachemnts(clusterIDOrName, workerID string, target ClusterTargetHeader) (VoulemeAttachments, error)
@@ -108,7 +110,7 @@ func newWorkerAPI(c *client.Client) Workers {
 	}
 }
 
-//ListByWorkerPool ...
+// ListByWorkerPool ...
 func (r *worker) ListByWorkerPool(clusterIDOrName, workerPoolIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error) {
 	rawURL := fmt.Sprintf("/v2/vpc/getWorkers?cluster=%s&showDeleted=%t", clusterIDOrName, showDeleted)
 	if len(workerPoolIDOrName) > 0 {
@@ -122,7 +124,7 @@ func (r *worker) ListByWorkerPool(clusterIDOrName, workerPoolIDOrName string, sh
 	return workers, err
 }
 
-//ListWorkers ...
+// ListWorkers ...
 func (r *worker) ListWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error) {
 	rawURL := fmt.Sprintf("/v2/vpc/getWorkers?cluster=%s&showDeleted=%t", clusterIDOrName, showDeleted)
 	workers := []Worker{}
@@ -133,7 +135,18 @@ func (r *worker) ListWorkers(clusterIDOrName string, showDeleted bool, target Cl
 	return workers, err
 }
 
-//Get ...
+// ListClassicWorkers ...
+func (r *worker) ListClassicWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error) {
+	rawURL := fmt.Sprintf("/v2/classic/getWorkers?cluster=%s&showDeleted=%t", clusterIDOrName, showDeleted)
+	workers := []Worker{}
+	_, err := r.client.Get(rawURL, &workers, target.ToMap())
+	if err != nil {
+		return nil, err
+	}
+	return workers, err
+}
+
+// Get ...
 func (r *worker) Get(clusterIDOrName, workerID string, target ClusterTargetHeader) (Worker, error) {
 	rawURL := fmt.Sprintf("/v2/vpc/getWorker?cluster=%s&worker=%s", clusterIDOrName, workerID)
 	worker := Worker{}

--- a/api/container/containerv2/workers_test.go
+++ b/api/container/containerv2/workers_test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	bluemix "github.com/IBM-Cloud/bluemix-go"
+	"github.com/IBM-Cloud/bluemix-go"
 	"github.com/IBM-Cloud/bluemix-go/client"
 	bluemixHttp "github.com/IBM-Cloud/bluemix-go/http"
 	"github.com/IBM-Cloud/bluemix-go/session"
@@ -93,6 +93,86 @@ var _ = Describe("Workers", func() {
 			It("should return error during get worker", func() {
 				target := ClusterTargetHeader{}
 				_, err := newWorker(server.URL()).ListByWorkerPool("aaa", "bbb", true, target)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	// ListClassicWorkers
+	Describe("ListClassicWorkers", func() {
+		Context("When ListClassicWorkers is successful", func() {
+			BeforeEach(func() {
+				server = ghttp.NewServer()
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						// https://containers.cloud.ibm.com/global/swagger-global-api/#/v2/classicGetWorkers
+						ghttp.VerifyRequest(http.MethodGet, "/v2/classic/getWorkers"),
+						ghttp.RespondWith(http.StatusOK, `[
+  {
+    "dedicatedHostId": "string",
+    "dedicatedHostPoolId": "string",
+    "flavor": "string",
+    "health": {
+      "message": "string",
+      "state": "string"
+    },
+    "id": "string",
+    "kubeVersion": {
+      "actual": "string",
+      "desired": "string",
+      "eos": "string",
+      "masterEOS": "string",
+      "target": "string"
+    },
+    "lifecycle": {
+      "actualOperatingSystem": "string",
+      "actualState": "string",
+      "desiredOperatingSystem": "string",
+      "desiredState": "string",
+      "message": "string",
+      "messageDate": "string",
+      "messageDetails": "string",
+      "messageDetailsDate": "string",
+      "pendingOperation": "string",
+      "reasonForDelete": "string"
+    },
+    "location": "string",
+    "networkInformation": {
+      "privateIP": "string",
+      "privateVLAN": "string",
+      "publicIP": "string",
+      "publicVLAN": "string"
+    },
+    "poolID": "string",
+    "poolName": "string"
+  }
+]`),
+					),
+				)
+			})
+
+			It("should list workers in a cluster", func() {
+				target := ClusterTargetHeader{}
+
+				_, err := newWorker(server.URL()).ListClassicWorkers("aaa", false, target)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		Context("When ListClassicWorkers is unsuccessful", func() {
+			BeforeEach(func() {
+				server = ghttp.NewServer()
+				server.SetAllowUnhandledRequests(true)
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest(http.MethodGet, "/v2/classic/getWorkers"),
+						ghttp.RespondWith(http.StatusInternalServerError, `Failed to list worker`),
+					),
+				)
+			})
+
+			It("should return error during get worker", func() {
+				target := ClusterTargetHeader{}
+				_, err := newWorker(server.URL()).ListClassicWorkers("aaa", false, target)
 				Expect(err).To(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
New endpoint needed for terraform. For testing against the real endpoint see the terraform PR: https://github.com/IBM-Cloud/terraform-provider-ibm/pull/5589

```
% go test ./api/container/containerv2/ -ginkgo.focus "SetWorkerPoolOperatingSystem"
ok      github.com/IBM-Cloud/bluemix-go/api/container/containerv2       90.970s
```