### PR TITLE
Changed v2/classic/getWorkers to v2/getWorkers

### DIFF
--- a/api/container/containerv2/workers.go
+++ b/api/container/containerv2/workers.go
@@ -91,7 +91,7 @@ type VolumeRequest struct {
 type Workers interface {
 	ListByWorkerPool(clusterIDOrName, workerPoolIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error)
 	ListWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error)
-	ListClassicWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error)
+	ListAllWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error)
 	Get(clusterIDOrName, workerID string, target ClusterTargetHeader) (Worker, error)
 	ReplaceWokerNode(clusterIDOrName, workerID string, target ClusterTargetHeader) (string, error)
 	ListStorageAttachemnts(clusterIDOrName, workerID string, target ClusterTargetHeader) (VoulemeAttachments, error)
@@ -124,7 +124,7 @@ func (r *worker) ListByWorkerPool(clusterIDOrName, workerPoolIDOrName string, sh
 	return workers, err
 }
 
-// ListWorkers ...
+// ListWorkers lists VPC workers
 func (r *worker) ListWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error) {
 	rawURL := fmt.Sprintf("/v2/vpc/getWorkers?cluster=%s&showDeleted=%t", clusterIDOrName, showDeleted)
 	workers := []Worker{}
@@ -135,9 +135,9 @@ func (r *worker) ListWorkers(clusterIDOrName string, showDeleted bool, target Cl
 	return workers, err
 }
 
-// ListClassicWorkers ...
-func (r *worker) ListClassicWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error) {
-	rawURL := fmt.Sprintf("/v2/classic/getWorkers?cluster=%s&showDeleted=%t", clusterIDOrName, showDeleted)
+// ListAllWorkers lists workers of every type
+func (r *worker) ListAllWorkers(clusterIDOrName string, showDeleted bool, target ClusterTargetHeader) ([]Worker, error) {
+	rawURL := fmt.Sprintf("/v2/getWorkers?cluster=%s&showDeleted=%t", clusterIDOrName, showDeleted)
 	workers := []Worker{}
 	_, err := r.client.Get(rawURL, &workers, target.ToMap())
 	if err != nil {

--- a/api/container/containerv2/workers_test.go
+++ b/api/container/containerv2/workers_test.go
@@ -103,8 +103,8 @@ var _ = Describe("Workers", func() {
 				server = ghttp.NewServer()
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
-						// https://containers.cloud.ibm.com/global/swagger-global-api/#/v2/classicGetWorkers
-						ghttp.VerifyRequest(http.MethodGet, "/v2/classic/getWorkers"),
+						// https://containers.cloud.ibm.com/global/swagger-global-api/#/v2/getWorkers
+						ghttp.VerifyRequest(http.MethodGet, "/v2/getWorkers"),
 						ghttp.RespondWith(http.StatusOK, `[
   {
     "dedicatedHostId": "string",
@@ -162,7 +162,7 @@ var _ = Describe("Workers", func() {
 				server.SetAllowUnhandledRequests(true)
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest(http.MethodGet, "/v2/classic/getWorkers"),
+						ghttp.VerifyRequest(http.MethodGet, "/v2/getWorkers"),
 						ghttp.RespondWith(http.StatusInternalServerError, `Failed to list worker`),
 					),
 				)

--- a/api/container/containerv2/workers_test.go
+++ b/api/container/containerv2/workers_test.go
@@ -8,11 +8,9 @@ import (
 	"github.com/IBM-Cloud/bluemix-go/client"
 	bluemixHttp "github.com/IBM-Cloud/bluemix-go/http"
 	"github.com/IBM-Cloud/bluemix-go/session"
-
-	"github.com/onsi/gomega/ghttp"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
 )
 
 var _ = Describe("Workers", func() {
@@ -98,9 +96,9 @@ var _ = Describe("Workers", func() {
 		})
 	})
 
-	// ListClassicWorkers
-	Describe("ListClassicWorkers", func() {
-		Context("When ListClassicWorkers is successful", func() {
+	// ListAllWorkers
+	Describe("ListAllWorkers", func() {
+		Context("When ListAllWorkers is successful", func() {
 			BeforeEach(func() {
 				server = ghttp.NewServer()
 				server.AppendHandlers(
@@ -154,11 +152,11 @@ var _ = Describe("Workers", func() {
 			It("should list workers in a cluster", func() {
 				target := ClusterTargetHeader{}
 
-				_, err := newWorker(server.URL()).ListClassicWorkers("aaa", false, target)
+				_, err := newWorker(server.URL()).ListAllWorkers("aaa", false, target)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
-		Context("When ListClassicWorkers is unsuccessful", func() {
+		Context("When ListAllWorkers is unsuccessful", func() {
 			BeforeEach(func() {
 				server = ghttp.NewServer()
 				server.SetAllowUnhandledRequests(true)
@@ -172,7 +170,7 @@ var _ = Describe("Workers", func() {
 
 			It("should return error during get worker", func() {
 				target := ClusterTargetHeader{}
-				_, err := newWorker(server.URL()).ListClassicWorkers("aaa", false, target)
+				_, err := newWorker(server.URL()).ListAllWorkers("aaa", false, target)
 				Expect(err).To(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
Changes `ListClassicWorkers` to `ListAllWorkers`, as the endpoint `/v2/classic/getWorkers` only exists in the regional APIs, causing 404s when requesting through global API.

Example response from endpoint:

### Before

```json
[
  {
    "id": "someID",
    "lifecycle": {
      "desiredState": "deployed",
      "actualState": "deployed",
      "message": "",
      "messageDate": "",
      "pendingOperation": "",
      "reasonForDelete": "",
      "messageDetails": "",
      "messageDetailsDate": "",
      "desiredOperatingSystem": "UBUNTU_24_64",
      "actualOperatingSystem": "UBUNTU_24_64"
    },
    "health": {
      "state": "normal",
      "message": "Ready"
    },
    "kubeVersion": {
      "desired": "1.30.5_1542",
      "actual": "1.30.5_1542",
      "target": "1.30.5_1542",
      "eos": "",
      "masterEOS": ""
    },
    "flavor": "fla",
    "location": "loc",
    "poolID": "someID-poolID",
    "poolName": "default",
    "networkInformation": {
      "publicIP": "pub",
      "privateIP": "pri",
      "publicVLAN": "pubVLAN",
      "privateVLAN": "priVLAN"
    }
  },
  ...
]
```

### After

```json
[
  {
    "id": "someID",
    "lifecycle": {
      "desiredState": "deployed",
      "actualState": "deployed",
      "message": "",
      "messageDate": "",
      "pendingOperation": "",
      "reasonForDelete": "",
      "messageDetails": "",
      "messageDetailsDate": "",
      "desiredOperatingSystem": "UBUNTU_24_64",
      "actualOperatingSystem": "UBUNTU_24_64"
    },
    "health": {
      "state": "normal",
      "message": "Ready"
    },
    "kubeVersion": {
      "desired": "1.30.5_1542",
      "actual": "1.30.5_1542",
      "target": "1.30.5_1542",
      "eos": "",
      "masterEOS": ""
    },
    "flavor": "fla",
    "location": "loc",
    "poolID": "someID-poolID",
    "poolName": "default",
    "networkInformation": {
      "publicIP": "pub",
      "privateIP": "pri",
      "publicVLAN": "pubVLAN",
      "privateVLAN": "priVLAN"
    }
  },
  ...
]
```