### PR TITLE
fix panic

### DIFF
--- a/api/container/containerv2/clusters.go
+++ b/api/container/containerv2/clusters.go
@@ -359,8 +359,8 @@ func (r *clusters) GetClusterConfigDetail(name, dir string, isAdmin bool, target
 	if len(config.Clusters) > 0 {
 		clusterkey.Host = config.Clusters[0].Cluster.Server
 	}
-	if len(config.AuthInfos) > 0 {
-		clusterkey.Token, _ = config.AuthInfos[0].AuthInfo.AuthProvider.Config["id-token"]
+	if len(config.AuthInfos) > 0 && config.AuthInfos[0].AuthInfo.AuthProvider != nil {
+		clusterkey.Token = config.AuthInfos[0].AuthInfo.AuthProvider.Config["id-token"]
 	}
 
 	// Block to add token for openshift clusters


### PR DESCRIPTION
fixes panic introduced in https://github.com/IBM-Cloud/bluemix-go/pull/463

Panic happens because with the model change `AuthProvider` is now a pointer, casuing a nil pointer dereference when the `admin` flag is provided and the field is assigned `nil`