### PR TITLE
Add NetworkPlugin field to ClusterCreateRequest and ClusterInfo

### DIFF
--- a/api/container/containerv2/clusters.go
+++ b/api/container/containerv2/clusters.go
@@ -33,6 +33,7 @@ type ClusterCreateRequest struct {
 	WorkerPools                      WorkerPoolConfig `json:"workerPool"`
 	SecurityGroupIDs                 []string         `json:"securityGroupIDs,omitempty"`
 	DisableOutboundTrafficProtection bool             `json:"disableOutboundTrafficProtection,omitempty"`
+	NetworkPlugin                    string           `json:"networkPlugin,omitempty"`
 }
 
 type WorkerPoolConfig struct {
@@ -100,6 +101,7 @@ type ClusterInfo struct {
 	Features                      Feat          `json:"features"`
 	ImageSecurityEnabled          bool          `json:"imageSecurityEnabled"`
 	VirtualPrivateEndpointURL     string        `json:"virtualPrivateEndpointURL"`
+	NetworkPlugin                 string        `json:"networkPlugin,omitempty"`
 }
 type Feat struct {
 	KeyProtectEnabled bool `json:"keyProtectEnabled"`


### PR DESCRIPTION
ROKS 4.20+ supports CNI selection at VPC cluster creation. This change is necessary to add this functionality to terraform-ibm-provider.