### PR TITLE
Add offering field to ClusterInfo

### DIFF
--- a/api/container/containerv2/clusters.go
+++ b/api/container/containerv2/clusters.go
@@ -103,6 +103,7 @@ type ClusterInfo struct {
 	ImageSecurityEnabled          bool          `json:"imageSecurityEnabled"`
 	VirtualPrivateEndpointURL     string        `json:"virtualPrivateEndpointURL"`
 	NetworkPlugin                 string        `json:"networkPlugin,omitempty"`
+	Offering                      string        `json:"offering"`
 }
 type Feat struct {
 	KeyProtectEnabled bool `json:"keyProtectEnabled"`


### PR DESCRIPTION
get/list cluster do support offering field now. This change is necessary to add this functionality to terraform-ibm-provider